### PR TITLE
switching to python3

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -5,6 +5,8 @@
    factor is halved.
 """
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 import random
 from cctbx import xray
 from libtbx import adopt_init_args
@@ -12,7 +14,7 @@ from scitbx.array_family import flex
 import cctbx.maptbx.real_space_refinement_simple
 import scitbx.lbfgs
 from libtbx import group_args
-import qr
+from .qr import *
 from mmtbx.validation.ramalyze import ramalyze
 from mmtbx.validation.cbetadev import cbetadev
 from mmtbx.validation.rotalyze import rotalyze
@@ -101,7 +103,7 @@ class weights(object):
     tc, gc = rm.target_and_gradients(sites_cart=xrs.sites_cart())
     x = gc.norm()
     y = gx.norm()
-    if verbose: print '>>> gradient norms c,x %0.2f %0.2f' % (x, y)
+    if verbose: print('>>> gradient norms c,x %0.2f %0.2f' % (x, y))
     # filter out large contributions
     gx_d = flex.sqrt(gx.dot())
     sel = gx_d>flex.mean(gx_d)*6
@@ -113,7 +115,7 @@ class weights(object):
     ################
     if(y != 0.0): self.data_weight = x/y
     else:         self.data_weight = 1.0 # ad hoc default fallback
-    if verbose: print '>>> data_weight %0.2f' % self.data_weight
+    if verbose: print('>>> data_weight %0.2f' % self.data_weight)
 
 class calculator(object):
   def __init__(self,
@@ -358,8 +360,8 @@ class sites_real_space(object):
     pdb_hierarchy = model.get_hierarchy(),
     keep_hydrogens = False, 
     fast = True, condensed_probe = True).get_clashscore()
-    print "DEV: b_rmsd= %7.4f clash= %6.4f rota= %6.4f rama_fav= %5.4f cbeta= %6.4f"%(
-    b_rmsd, clash, rota, rama_fav, cbeta)
+    print("DEV: b_rmsd= %7.4f clash= %6.4f rota= %6.4f rama_fav= %5.4f cbeta= %6.4f"%(
+    b_rmsd, clash, rota, rama_fav, cbeta))
     return group_args(
       rama_fav = rama_fav, cbeta = cbeta, rota = rota, b_rmsd = b_rmsd, clash = clash)
 
@@ -372,7 +374,7 @@ class sites_real_space(object):
             abs(sc.clash-self.clash_best)>1.)
 
   def macro_cycle(self, weights):
-    print "RSR: weights to try:", weights
+    print("RSR: weights to try:", weights)
     weight_best = None
     i_best = None
     model_best = None
@@ -404,7 +406,7 @@ class sites_real_space(object):
           model_best = models[i_best]
           break
       #
-    print "RSR: weight_best:", weight_best
+    print("RSR: weight_best:", weight_best)
     return model_best, weight_best, i_best
 
   def run(self):
@@ -426,9 +428,9 @@ class sites_real_space(object):
     elif(weight == 0.01):
       new_weights = [0.01,0.02,0.03,0.04,0.05,0.06,0.07,0.08,0.09]
     else:
-      print "RSR: FALED TO FIND BEST WEIGHT"
+      print("RSR: FALED TO FIND BEST WEIGHT")
       STOP()
-    print "RSR: new_weights:", new_weights
+    print("RSR: new_weights:", new_weights)
     #
     model_, weight_, i_ = self.macro_cycle(weights = new_weights)
     self.model  = model
@@ -456,8 +458,8 @@ class sites_real_space(object):
     else:                        w = "%5s"%str(None)
     cc_mask = qr.show_cc(
       map_data=self.map_data, xray_structure=model.get_xray_structure())
-    print "RSR", prefix, "weight=%s"%w, s, "shift=%6.4f"%dist, \
-      "cc_mask=%6.4f"%cc_mask
+    print("RSR", prefix, "weight=%s"%w, s, "shift=%6.4f"%dist, \
+      "cc_mask=%6.4f"%cc_mask)
     with open("weight_%s.pdb"%w.strip(), "w") as of:
       of.write(model.model_as_pdb())
 

--- a/charges.py
+++ b/charges.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import sys
 from libtbx.utils import Sorry
@@ -5,7 +7,7 @@ import iotbx
 from mmtbx.chemical_components import get_cif_dictionary
 from mmtbx.monomer_library import server
 
-from utils import hierarchy_utils
+from qrefine.utils import hierarchy_utils
 from iotbx.pdb import amino_acid_codes as aac
 
 get_class = iotbx.pdb.common_residue_names_get_class
@@ -239,8 +241,8 @@ class charges_class:
     qxyz_file.close()
 
     if outl:
-      print 'WARNINGS'
-      print outl
+      print('WARNINGS')
+      print(outl)
       raise Sorry('point charges are not set.')
 
   def calculate_residue_charge(self,
@@ -252,7 +254,7 @@ class charges_class:
                                verbose=False,
                                ):
     if self.verbose: verbose=True
-    if verbose: print '-'*80
+    if verbose: print('-'*80)
     def _terminal(names, check):
       for name in check:
         if name not in names:
@@ -326,17 +328,17 @@ class charges_class:
     atom_names = []
     atom_i_seqs = []
     for atom in rg.atoms():
-      if verbose: print '...',atom.quote()
+      if verbose: print('...',atom.quote())
       if atom.element_is_hydrogen(): hs+=1
       atom_names.append(atom.name)
       atom_i_seqs.append(atom.i_seq)
-    if verbose: print get_class(resname)
+    if verbose: print(get_class(resname))
     if assert_contains_hydrogens:
       if hs==0:
         hydrogens = get_aa_polymer_hydrogens(resname)
         if len(hydrogens)!=0:
           if verbose:
-            for atom in rg.atoms(): print 'H',atom.quote()
+            for atom in rg.atoms(): print('H',atom.quote())
           raise Sorry("no hydrogens: %s" % hierarchy_utils.display_residue_group(rg))
     ag = rg.atom_groups()[0]
     charge = get_aa_charge(ag.resname)
@@ -345,93 +347,93 @@ class charges_class:
       rc=-1 # reporting only
     annot = ''
     if verbose:
-      print '%s\nstarting charge: %s' % ('*'*80, charge)
+      print('%s\nstarting charge: %s' % ('*'*80, charge))
     if ( get_class(ag.resname) in ["common_amino_acid", "modified_amino_acid"] or
          ag.resname in aac.three_letter_l_given_three_letter_d
          ):
       if verbose:
-        print ag.id_str()
-        print 'number of hydrogens',len(get_aa_polymer_hydrogens(ag.resname))
+        print(ag.id_str())
+        print('number of hydrogens',len(get_aa_polymer_hydrogens(ag.resname)))
       poly_hs = len(get_aa_polymer_hydrogens(ag.resname))-2
       diff_hs = hs-poly_hs
-      if verbose: print 'charge: %s poly_hs: %s diff_hs: %s' % (charge,
+      if verbose: print('charge: %s poly_hs: %s diff_hs: %s' % (charge,
                                                                 poly_hs,
                                                                 diff_hs,
-                                                              )
-      if verbose: print atom_names
+                                                              ))
+      if verbose: print(atom_names)
       if n_terminal(ag.resname, atom_names):
         diff_hs-=1
         max_charge+=1
         if verbose:
-          print 'n_terminal'
-          print 'charge: %s poly_hs: %s diff_hs: %s' % (charge,
+          print('n_terminal')
+          print('charge: %s poly_hs: %s diff_hs: %s' % (charge,
                                                         poly_hs,
                                                         diff_hs,
-          )
+          ))
         annot += 'N-term. '
       elif nh3_terminal(atom_names):
         diff_hs-=1
         max_charge+=1
-        if verbose: print 'nh3_terminal True'
+        if verbose: print('nh3_terminal True')
         annot += 'NH3-term. '
       elif nh2_terminal(atom_names):
         diff_hs-=1
         max_charge+=1
-        if verbose: print 'nh2_terminal True'
+        if verbose: print('nh2_terminal True')
         annot += 'NH2-term. '
       elif n_capping(ag.resname, atom_names):
         diff_hs-=1
-        if verbose: print 'n_capping True'
+        if verbose: print('n_capping True')
         annot += 'N-capp. '
       else:
-        if verbose: print 'no N term'
+        if verbose: print('no N term')
       if c_terminal(atom_names):
         diff_hs-=1
         max_charge+=1
         if verbose:
-          print 'c_terminal'
-          print 'charge: %s poly_hs: %s diff_hs: %s' % (charge,
+          print('c_terminal')
+          print('charge: %s poly_hs: %s diff_hs: %s' % (charge,
                                                         poly_hs,
                                                         diff_hs,
-                                                      )
+                                                      ))
         annot += 'C-term. '
       elif c_capping(atom_names):
         diff_hs-=1
         #max_charge+=1
         if verbose:
-          print 'c_capping'
-          print 'charge: %s poly_hs: %s diff_hs: %s' % (charge,
+          print('c_capping')
+          print('charge: %s poly_hs: %s diff_hs: %s' % (charge,
                                                         poly_hs,
                                                         diff_hs,
-                                                      )
+                                                      ))
         annot += 'C-capp. '
       else:
-        if verbose: print 'no C term'
+        if verbose: print('no C term')
       if covalent_bond(atom_i_seqs, inter_residue_bonds):
         diff_hs+=1
         if verbose:
-          print 'covalent_bond',atom_i_seqs#, inter_residue_bonds
+          print('covalent_bond',atom_i_seqs)#, inter_residue_bonds
         annot += 'Coval. '
       if hierarchy_utils.is_n_terminal_atom_group(ag):
-        if verbose: print 'subtracting due to N terminal'
+        if verbose: print('subtracting due to N terminal')
         diff_hs-=1
       if verbose:
-        print 'residue: %s charge: %s poly_hs: %2s diff_hs: %2s total: %2s %s' % (
+        print('residue: %s charge: %s poly_hs: %2s diff_hs: %2s total: %2s %s' % (
           ag.resname,
           charge,
           poly_hs,
           diff_hs,
           charge+diff_hs,
           annot,
-        )
+        ))
       charge+=diff_hs
       if charge: verbose=0
       if verbose:
-        print '  %s charge: %-2s poly_hs: %s diff_hs: %-2s' % (ag.id_str(),
+        print('  %s charge: %-2s poly_hs: %s diff_hs: %-2s' % (ag.id_str(),
                                                                charge,
                                                                poly_hs,
                                                                diff_hs,
-                                                             )
+                                                             ))
       assert abs(charge)<=max_charge, 'residue %s charge %s is greater than %s' % (
         rg.atoms()[0].quote(),
         charge,
@@ -517,15 +519,15 @@ class charges_class:
         charge = tmp
         break
       if check:
-        print residue
+        print(residue)
         key = 'PRO%s' % residue.parent().id
         key += '.%s' % residue.resseq.strip()
         key += '.%s' % residue.atom_groups()[0].resname
         key = key.replace('HIS', 'HSD')
-        print key
-        print ' CHARMM %f Phenix %f' % (check[key], tmp)
+        print(key)
+        print(' CHARMM %f Phenix %f' % (check[key], tmp))
         if 1:
-          print inter_residue_bonds
+          print(inter_residue_bonds)
         assert abs(check[key]-tmp)<0.001
         assert 0
       if list_charges:
@@ -546,7 +548,7 @@ class charges_class:
             assert abs(tmp-rc)<=2, outl
             outl += "\n%s" % atom.quote()
           outl += '\n%s' % ('-'*80)
-          print outl
+          print(outl)
     # check annotations
     if residue_types and assert_correct_chain_terminii:
       assert filter(None, annotations), 'No terminal or capping hydrogens found'
@@ -634,7 +636,7 @@ def calculate_residue_charge(rg,
                              inter_residue_bonds=None,
                              verbose=False,
                              ):
-  if verbose: print '-'*80
+  if verbose: print('-'*80)
   def _terminal(names, check):
     for name in check:
       if name not in names:
@@ -708,17 +710,17 @@ def calculate_residue_charge(rg,
   atom_names = []
   atom_i_seqs = []
   for atom in rg.atoms():
-    if verbose: print '...',atom.quote()
+    if verbose: print('...',atom.quote())
     if atom.element_is_hydrogen(): hs+=1
     atom_names.append(atom.name)
     atom_i_seqs.append(atom.i_seq)
-  if verbose: print get_class(resname)
+  if verbose: print(get_class(resname))
   if assert_contains_hydrogens:
     if hs==0:
       hydrogens = get_aa_polymer_hydrogens(resname)
       if len(hydrogens)!=0:
         if verbose:
-          for atom in rg.atoms(): print 'H',atom.quote()
+          for atom in rg.atoms(): print('H',atom.quote())
         raise Sorry("no hydrogens: %s" % hierarchy_utils.display_residue_group(rg))
   ag = rg.atom_groups()[0]
   charge = get_aa_charge(ag.resname)
@@ -727,92 +729,92 @@ def calculate_residue_charge(rg,
     rc=-1 # reporting only
   annot = ''
   if verbose:
-    print '%s\nstarting charge: %s' % ('*'*80, charge)
+    print('%s\nstarting charge: %s' % ('*'*80, charge))
   if ( get_class(ag.resname) in ["common_amino_acid", "modified_amino_acid"] or
        ag.resname in aac.three_letter_l_given_three_letter_d
        ):
     if verbose:
-      print ag.id_str()
-      print 'number of hydrogens',len(get_aa_polymer_hydrogens(ag.resname))
+      print(ag.id_str())
+      print('number of hydrogens',len(get_aa_polymer_hydrogens(ag.resname)))
     poly_hs = len(get_aa_polymer_hydrogens(ag.resname))-2
     diff_hs = hs-poly_hs
-    if verbose: print 'charge: %s poly_hs: %s diff_hs: %s' % (charge,
+    if verbose: print('charge: %s poly_hs: %s diff_hs: %s' % (charge,
                                                               poly_hs,
                                                               diff_hs,
-                                                            )
-    if verbose: print atom_names
+                                                            ))
+    if verbose: print(atom_names)
     if n_terminal(ag.resname, atom_names):
       diff_hs-=1
       max_charge+=1
       if verbose:
-        print 'n_terminal'
-        print 'charge: %s poly_hs: %s diff_hs: %s' % (charge,
+        print('n_terminal')
+        print('charge: %s poly_hs: %s diff_hs: %s' % (charge,
                                                       poly_hs,
                                                       diff_hs,
-        )
+        ))
       annot += 'N-term. '
     elif nh3_terminal(atom_names):
       diff_hs-=1
       max_charge+=1
-      if verbose: print 'nh3_terminal True'
+      if verbose: print('nh3_terminal True')
       annot += 'NH3-term. '
     elif nh2_terminal(atom_names):
       diff_hs-=1
       max_charge+=1
-      if verbose: print 'nh2_terminal True'
+      if verbose: print('nh2_terminal True')
       annot += 'NH2-term. '
     elif n_capping(ag.resname, atom_names):
       diff_hs-=1
-      if verbose: print 'n_capping True'
+      if verbose: print('n_capping True')
       annot += 'N-capp. '
     else:
-      if verbose: print 'no N term'
+      if verbose: print('no N term')
     if c_terminal(atom_names):
       diff_hs-=1
       max_charge+=1
       if verbose:
-        print 'c_terminal'
-        print 'charge: %s poly_hs: %s diff_hs: %s' % (charge,
+        print('c_terminal')
+        print('charge: %s poly_hs: %s diff_hs: %s' % (charge,
                                                       poly_hs,
                                                       diff_hs,
-                                                    )
+                                                    ))
       annot += 'C-term. '
     elif c_capping(atom_names):
       diff_hs-=1
       #max_charge+=1
       if verbose:
-        print 'c_capping'
-        print 'charge: %s poly_hs: %s diff_hs: %s' % (charge,
+        print('c_capping')
+        print('charge: %s poly_hs: %s diff_hs: %s' % (charge,
                                                       poly_hs,
                                                       diff_hs,
-                                                    )
+                                                    ))
       annot += 'C-capp. '
     else:
-      if verbose: print 'no C term'
+      if verbose: print('no C term')
     if covalent_bond(atom_i_seqs, inter_residue_bonds):
       diff_hs+=1
       if verbose:
-        print 'covalent_bond',atom_i_seqs, inter_residue_bonds
+        print('covalent_bond',atom_i_seqs, inter_residue_bonds)
       annot += 'Coval. '
     if hierarchy_utils.is_n_terminal_atom_group(ag):
       diff_hs-=1
     if verbose:
-      print 'residue: %s charge: %s poly_hs: %2s diff_hs: %2s total: %2s %s' % (
+      print('residue: %s charge: %s poly_hs: %2s diff_hs: %2s total: %2s %s' % (
         ag.resname,
         charge,
         poly_hs,
         diff_hs,
         charge+diff_hs,
         annot,
-      )
+      ))
     charge+=diff_hs
     if charge: verbose=0
     if verbose:
-      print '  %s charge: %-2s poly_hs: %s diff_hs: %-2s' % (ag.id_str(),
+      print('  %s charge: %-2s poly_hs: %s diff_hs: %-2s' % (ag.id_str(),
                                                              charge,
                                                              poly_hs,
                                                              diff_hs,
-                                                           )
+                                                           ))
     assert abs(charge)<=max_charge, 'residue %s charge %s is greater than %s' % (
       rg.atoms()[0].quote(),
       charge,
@@ -979,11 +981,11 @@ def get_hetero_charges_DB(pdb_hierarchy):
   for atom_group in pdb_hierarchy.atom_groups():
     restraints = _get_restraints_from_resname(atom_group.resname)
     if restraints.is_peptide():
-      print 'PEPTIDE',atom_group.resname
+      print('PEPTIDE',atom_group.resname)
       continue
-    print atom_group.resname
-    print restraints
-    print dir(restraints)
+    print(atom_group.resname)
+    print(restraints)
+    print(dir(restraints))
     restraints.show()
     get_charge_from_restraints(atom_group.resname)
   assert 0
@@ -1016,7 +1018,7 @@ def get_inter_residue_bonds(ppf, verbose=False):
       if r1.id_str()!=r2.id_str():
         inter_residue_bonds[p.i_seqs] = True
         if verbose:
-          print 'bonding',atoms[p.i_seqs[0]].quote(), atoms[p.i_seqs[1]].quote()
+          print('bonding',atoms[p.i_seqs[0]].quote(), atoms[p.i_seqs[1]].quote())
         for i in range(2):
           inter_residue_bonds.setdefault(p.i_seqs[i], [])
           inter_residue_bonds[p.i_seqs[i]].append(inter_residue_bonds[p.i_seqs])
@@ -1060,4 +1062,4 @@ if __name__=="__main__":
   if len(args)>1 and args[1]:
     list_charges=True
   total_charge = run(*tuple(args), list_charges=list_charges)
-  print "total_charge",total_charge
+  print("total_charge",total_charge)

--- a/cluster_restraints.py
+++ b/cluster_restraints.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 from libtbx import Auto
@@ -6,8 +8,8 @@ from libtbx.utils import Sorry
 from libtbx import adopt_init_args
 from libtbx.easy_mp import parallel_map
 from scitbx.array_family import flex
-from fragment import fragment_extracts, write_cluster_and_fragments_pdbs
-from restraints import from_qm
+from .fragment import fragment_extracts, write_cluster_and_fragments_pdbs
+from .restraints import from_qm
 from libtbx import group_args
 
 def check_no_altlocs(h, file_name):
@@ -99,8 +101,8 @@ class from_cluster(object):
           print('Directory not copied. Error: %s' % e)
         ncount=ncount+1
         energy_gradients=None
-        print "check independent QM jobs"
-        print e
+        print("check independent QM jobs")
+        print(e)
         raise Sorry('process finished with error: %s' % e)
     target=0
     gradients=flex.vec3_double(system_size)

--- a/cluster_restraints.py
+++ b/cluster_restraints.py
@@ -89,6 +89,7 @@ class from_cluster(object):
           use_manager                = True)
       except Exception as e:
         import shutil
+        import traceback
         if os.path.exists('ase_error'):
           shutil.rmtree('ase_error')
         try:
@@ -103,6 +104,7 @@ class from_cluster(object):
         energy_gradients=None
         print("check independent QM jobs")
         print(e)
+        traceback.print_exc()
         raise Sorry('process finished with error: %s' % e)
     target=0
     gradients=flex.vec3_double(system_size)

--- a/clustering.py
+++ b/clustering.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import absolute_import
 from boost_adaptbx import graph
 from boost_adaptbx.graph import clustering_algorithm
 from boost_adaptbx.graph import connected_component_algorithm as cca
@@ -24,7 +25,7 @@ class girvan_nweman_clustering(object):
     try:
       import networkx as nx
       import plugin.cmty as gn
-    except ImportError, e:
+    except ImportError as e:
       raise Sorry(str(e))
     Gx = nx.Graph()
     if self.size is not None:
@@ -43,7 +44,7 @@ class girvan_nweman_clustering(object):
     try:
       import networkx as nx
       import plugin.cmty as gn
-    except ImportError, e:
+    except ImportError as e:
       raise Sorry(str(e))
     if len(cluster) < self.maxnum_residues_in_cluster:
       final.append(cluster)

--- a/command_line/build_interfaces.py
+++ b/command_line/build_interfaces.py
@@ -198,7 +198,7 @@ def run():
     ''')
     for env_var, help in qm_engine_env_vars.items():
       print('%s %s : %s' % (' '*10, env_var, help))
-    print
+    print()
 
 
   draw_box_around_text(['','Done!','','Run a Q|R job using qr.refine','','https://github.com/qrefine/qrefine/wiki/Installation'])

--- a/command_line/charge.py
+++ b/command_line/charge.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 # LIBTBX_SET_DISPATCHER_NAME qr.charges
 import sys, time
 from qrefine import charges, __version__
@@ -45,12 +46,12 @@ def master_params():
   return iotbx.phil.parse(master_params_str, process_includes=True)
 
 def print_legend_and_usage(log):
-  print >> log, "-"*79
-  print >> log, "                               qr.charges"
-  print >> log, "-"*79
-  print >> log, legend
-  print >> log, "-"*79
-  print >> log, master_params().show()
+  print("-"*79, file=log)
+  print("                               qr.charges", file=log)
+  print("-"*79, file=log)
+  print(legend, file=log)
+  print("-"*79, file=log)
+  print(master_params().show(), file=log)
 
 def get_inputs(args, log, master_params):
   inputs = mmtbx.utils.process_command_line_args(
@@ -80,8 +81,8 @@ def run(args, log):
     #validated     = validated,
   )
   if(params.verbose):
-    print >> log,"Starting Q|R charge"
-    print >> log,'version: ',__version__
+    print("Starting Q|R charge", file=log)
+    print('version: ',__version__, file=log)
   del sys.argv[1:]
   cc = charges.charges_class(
     params.model_file_name,
@@ -94,12 +95,12 @@ def run(args, log):
     assert_correct_chain_terminii=params.assert_correct_chain_terminii,
   )
   if(params.verbose):
-    print >> log, 'Charge: %s' % rc
-    print >> log, "Time: %6.4f" % (time.time() - t0)
+    print('Charge: %s' % rc, file=log)
+    print("Time: %6.4f" % (time.time() - t0), file=log)
   if(params.list_charges):
-    print >> log, 'Charges:'
-    print >> log, rc
-    print >> log, "Time: %6.4f" % (time.time() - t0)
+    print('Charges:', file=log)
+    print(rc, file=log)
+    print("Time: %6.4f" % (time.time() - t0), file=log)
 
 
 if __name__ == '__main__':

--- a/command_line/cluster.py
+++ b/command_line/cluster.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 # LIBTBX_SET_DISPATCHER_NAME qr.cluster
 import sys
 import time
@@ -17,7 +18,7 @@ Cluster a system into many small pieces
 """
 
 def run(pdb_file, log,  maxnum_residues_in_cluster=15):
-  print >> log, "max number of residues in each cluster:\n", maxnum_residues_in_cluster
+  print("max number of residues in each cluster:\n", maxnum_residues_in_cluster, file=log)
   pdb_inp = iotbx.pdb.input(pdb_file)
   ph = pdb_inp.construct_hierarchy()
   cs = pdb_inp.crystal_symmetry()
@@ -26,7 +27,7 @@ def run(pdb_file, log,  maxnum_residues_in_cluster=15):
     crystal_symmetry=cs,
     maxnum_residues_in_cluster=int(maxnum_residues_in_cluster),
     qm_run=False)# not run qm_calculation, just the clustering result
-  print >> log, "Residue indices for each cluster:\n", fq.clusters
+  print("Residue indices for each cluster:\n", fq.clusters, file=log)
 
 
 if (__name__ == "__main__"):
@@ -34,4 +35,4 @@ if (__name__ == "__main__"):
   args = sys.argv[1:]
   del sys.argv[1:]
   run(args[0], log)
-  print >> log, "Time: %6.4f" % (time.time() - t0)
+  print("Time: %6.4f" % (time.time() - t0), file=log)

--- a/command_line/finalise.py
+++ b/command_line/finalise.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 # LIBTBX_SET_DISPATCHER_NAME qr.finalise
 import sys, time
 from qrefine import finalise, __version__
@@ -42,12 +43,12 @@ def master_params():
   return iotbx.phil.parse(master_params_str, process_includes=True)
 
 def print_legend_and_usage(log):
-  print >> log, "-"*79
-  print >> log, "                               qr.finalise"
-  print >> log, "-"*79
-  print >> log, legend
-  print >> log, "-"*79
-  print >> log, master_params().show()
+  print("-"*79, file=log)
+  print("                               qr.finalise", file=log)
+  print("-"*79, file=log)
+  print(legend, file=log)
+  print("-"*79, file=log)
+  print(master_params().show(), file=log)
 
 def get_inputs(args, log, master_params):
   inputs = mmtbx.utils.process_command_line_args(
@@ -89,7 +90,7 @@ def run(args, log):
 
 if __name__ == '__main__':
   t0 = time.time()
-  print >> log,"Starting Q|R finalise"
-  print >> log,'version: ',__version__
+  print("Starting Q|R finalise", file=log)
+  print('version: ',__version__, file=log)
   run(args=sys.argv[1:], log=log)
-  print >> log, "Time: %6.4f" % (time.time() - t0)
+  print("Time: %6.4f" % (time.time() - t0), file=log)

--- a/command_line/fqm_mopac.py
+++ b/command_line/fqm_mopac.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 # LIBTBX_SET_DISPATCHER_NAME qr.fqm_mopac
 import sys
 import time
@@ -42,8 +43,8 @@ def get_qm_energy(qm_engine, fragments_extracted, index):
                        index=index)
     atoms = ase_atoms_from_pdb_hierarchy(ph)
     qm_engine.label = qm_pdb_file[:-4]
-    print 'LABEL',qm_engine.label
-    print 'qm_charge',qm_charge
+    print('LABEL',qm_engine.label)
+    print('qm_charge',qm_charge)
     qm_engine.run_qr(atoms,
                      charge=qm_charge,
                      pointcharges=None,
@@ -84,7 +85,7 @@ def run(pdb_file, log):
   pdb_inp = iotbx.pdb.input(pdb_file)
   ph = pdb_inp.construct_hierarchy()
   cs = pdb_inp.crystal_symmetry()
-  print >> log, '\n\tfragmenting "%s"' % pdb_file
+  print('\n\tfragmenting "%s"' % pdb_file, file=log)
   t0=time.time()
   #
   # use a pickle file of fragments so testing of parallel is snappy
@@ -97,8 +98,8 @@ def run(pdb_file, log):
       charge_embedding=True,
       debug=False,
       qm_engine_name="orca")
-    print >> log, '\n\tfragmenting took %0.1f\n' % (time.time()-t0)
-    print >> log, "Residue indices for each cluster:\n", fq.clusters
+    print('\n\tfragmenting took %0.1f\n' % (time.time()-t0), file=log)
+    print("Residue indices for each cluster:\n", fq.clusters, file=log)
     fq_ext = fragment_extracts(fq)
     f=file(fq_fn, 'wb')
     pickle.dump(fq_ext, f)
@@ -122,7 +123,7 @@ def run(pdb_file, log):
                  indices,
                  processes=6,
     )
-    print rc
+    print(rc)
   elif 0:
     #
     # use multi_core_run
@@ -138,16 +139,16 @@ def run(pdb_file, log):
                                                       argss,
                                                       nproc,
                                                       ):
-      print '%sTotal time: %6.2f (s)' % (' '*7, time.time()-t0)
-      print args[-1], res
+      print('%sTotal time: %6.2f (s)' % (' '*7, time.time()-t0))
+      print(args[-1], res)
       if err_str:
-        print 'Error output from %s' % args
-        print err_str
-        print '_'*80
+        print('Error output from %s' % args)
+        print(err_str)
+        print('_'*80)
       results.append([args, res, err_str])
-    print '-'*80
+    print('-'*80)
     for args, res, err_str in results:
-      print args[-1], res
+      print(args[-1], res)
   else:
     #
     # serial
@@ -155,9 +156,9 @@ def run(pdb_file, log):
     #for i in xrange(len(fq.clusters)):
     for i in range(len(fq_ext.fragment_selections)):
       # add capping for the cluster and buffer
-      print >> log, "capping frag:", i
+      print("capping frag:", i, file=log)
       energy = get_qm_energy(qm_engine, fq_ext, i)
-      print >> log, " frag:", i, "  energy:", energy, ' time:', print_time(time.time()-t0)
+      print(" frag:", i, "  energy:", energy, ' time:', print_time(time.time()-t0), file=log)
       time.sleep(10)
 
 if (__name__ == "__main__"):
@@ -165,4 +166,4 @@ if (__name__ == "__main__"):
   args = sys.argv[1:]
   del sys.argv[1:]
   run(args[0], log)
-  print >> log, "Time: %s" % print_time(time.time() - t0)
+  print("Time: %s" % print_time(time.time() - t0), file=log)

--- a/command_line/fragmentation.py
+++ b/command_line/fragmentation.py
@@ -33,7 +33,7 @@ def run(pdb_file, log):
     qm_engine_name="terachem")
   print("Residue indices for each cluster:\n", fq.clusters, file=log)
   fq_ext = fragment_extracts(fq)
-  for i in xrange(len(fq.clusters)):
+  for i in range(len(fq.clusters)):
       # add capping for the cluster and buffer
       print("capping frag:", i, file=log)
       get_qm_file_name_and_pdb_hierarchy(

--- a/command_line/fragmentation.py
+++ b/command_line/fragmentation.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 # LIBTBX_SET_DISPATCHER_NAME qr.fragmentation
 import sys
 import time
@@ -30,15 +31,15 @@ def run(pdb_file, log):
     charge_embedding=True,
     debug=True,
     qm_engine_name="terachem")
-  print >> log, "Residue indices for each cluster:\n", fq.clusters
+  print("Residue indices for each cluster:\n", fq.clusters, file=log)
   fq_ext = fragment_extracts(fq)
   for i in xrange(len(fq.clusters)):
       # add capping for the cluster and buffer
-      print >> log, "capping frag:", i
+      print("capping frag:", i, file=log)
       get_qm_file_name_and_pdb_hierarchy(
                           fragment_extracts=fq_ext,
                           index=i)
-      print >>log, "point charge file:", i
+      print("point charge file:", i, file=log)
       #write mm point charge file
       write_mm_charge_file(fragment_extracts=fq_ext,
                                       index=i)
@@ -50,4 +51,4 @@ if (__name__ == "__main__"):
   args = sys.argv[1:]
   del sys.argv[1:]
   run(args[0], log)
-  print >> log, "Time: %6.4f" % (time.time() - t0)
+  print("Time: %6.4f" % (time.time() - t0), file=log)

--- a/command_line/qm2phenix.py
+++ b/command_line/qm2phenix.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # LIBTBX_SET_DISPATCHER_NAME qr.development.qm_to_phenix_pdb
 import os, sys
 
@@ -46,7 +47,7 @@ def read_cartesian_coordinates(filename):
   return coords
 
 def main(input_filename, master):
-  print input_filename, master
+  print(input_filename, master)
   coords = read_cartesian_coordinates(input_filename)
   pdb_inp = pdb.input(master)
   hierarchy = pdb_inp.construct_hierarchy()
@@ -54,10 +55,10 @@ def main(input_filename, master):
   for i in range(len(coords)):
     assert len(hierarchy.atoms())==len(coords[i])
     for atom, new in zip(hierarchy.atoms(), coords[i]):
-      print atom.quote(), atom.xyz, new
+      print(atom.quote(), atom.xyz, new)
       atom.xyz = new
     output_filename='%s_%05d.pdb' % (os.path.splitext(input_filename)[0], i+1)
-    print output_filename
+    print(output_filename)
     hierarchy.write_pdb_file(output_filename)
 
 if __name__ == '__main__':

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 # LIBTBX_SET_DISPATCHER_NAME qr.refine
 import os
 import sys
@@ -26,7 +27,7 @@ Refine a model using restraints from Quantum Chemistry
 """
 
 def get_help():
-  print legend
+  print(legend)
   raise Usage("""
     qr.refine is an open-source module that carries out refinement of bio-macromolecules
     utilizing chemical restraints from ab initio calculations.
@@ -46,10 +47,10 @@ def get_master_phil():
     phil_string=qr.master_params_str)
 
 def print_legend_and_usage(log):
-  print >> log, "-"*79
-  print >> log, legend
-  print >> log, "-"*79
-  print >> log, get_master_phil().show()
+  print("-"*79, file=log)
+  print(legend, file=log)
+  print("-"*79, file=log)
+  print(get_master_phil().show(), file=log)
 
 def reflection_file_server(crystal_symmetry, reflection_files):
   return reflection_file_utils.reflection_file_server(
@@ -69,9 +70,9 @@ def run(args, log):
     print_legend_and_usage(log)
     return  
   elif('--version' in args):
-    print __version__
+    print(__version__)
     return
-  print >> log,"Running refinement"
+  print("Running refinement", file=log)
   cmdline.params.show(out=log, prefix="   ")
   params = cmdline.params.extract()
 
@@ -86,7 +87,7 @@ def run(args, log):
   fmodel = None
   if(params.refine.mode=="opt" or params.refine.mode=='gtest'):
     if (len(cmdline.reflection_files)>0 or cmdline.ccp4_map is not None):
-      print >> log, "WARNING: data files not used in optimization or gradient test! "
+      print("WARNING: data files not used in optimization or gradient test! ", file=log)
   elif(len(cmdline.reflection_files)>0 and params.refine.mode=="refine"):
     # Read reflection data
     rfs = reflection_file_server(
@@ -102,7 +103,7 @@ def run(args, log):
     test_flag_value = determine_data_and_flags_result.test_flag_value
     if(r_free_flags is None):
       r_free_flags=f_obs.generate_r_free_flags()
-      print >> log, "WARNING: no free-R flags available in inputs. "
+      print("WARNING: no free-R flags available in inputs. ", file=log)
     fmodel = mmtbx.f_model.manager(
       f_obs          = f_obs,
       r_free_flags   = r_free_flags,
@@ -111,8 +112,8 @@ def run(args, log):
     if(params.refine.update_all_scales):
       fmodel.update_all_scales(remove_outliers=False)
       fmodel.show(show_header=False, show_approx=False)
-    print >> log, "Initial r_work=%6.4f r_free=%6.4f" % (fmodel.r_work(),
-      fmodel.r_free())
+    print("Initial r_work=%6.4f r_free=%6.4f" % (fmodel.r_work(),
+      fmodel.r_free()), file=log)
   elif(cmdline.ccp4_map is not None and params.refine.mode=="refine"): 
     # Read map
     map_data = cmdline.ccp4_map.map_data()
@@ -143,7 +144,7 @@ def run(args, log):
 
 if __name__ == '__main__':
   t0 = time.time()
-  print >> log,"Starting Q|R"
-  print >> log,'version: ',__version__
+  print("Starting Q|R", file=log)
+  print('version: ',__version__, file=log)
   run(args=sys.argv[1:], log=log)
-  print >> log, "Time: %6.4f" % (time.time() - t0)
+  print("Time: %6.4f" % (time.time() - t0), file=log)

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -11,12 +11,12 @@ import mmtbx.command_line
 from qrefine import qr, __version__
 from mmtbx import utils
 from iotbx import reflection_file_utils
-from cStringIO import StringIO
+from io import StringIO
 from libtbx import group_args
 from libtbx.utils import Sorry,Usage
 from scitbx.array_family import flex
 
-phenix_source = os.path.dirname(libtbx.env.dist_path("phenix"))
+# phenix_source = os.path.dirname(libtbx.env.dist_path("phenix"))
 qrefine_path = libtbx.env.find_in_repositories("qrefine")
 example_path = os.path.join(qrefine_path,"examples")
 

--- a/command_line/restraint.py
+++ b/command_line/restraint.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 # LIBTBX_SET_DISPATCHER_NAME qr.restraint
 import sys
 import time
@@ -23,7 +24,7 @@ Compute energy and gradient for a system
 
 
 def get_help():
-  print legend
+  print(legend)
   raise Usage("""
     qr.restraint is an open-source module that computes chemical restraints from ab initio calculations.
 
@@ -43,10 +44,10 @@ def get_master_phil():
     phil_string=qr.master_params_str)
 
 def print_legend_and_usage(log):
-  print >> log, "-"*79
-  print >> log, legend
-  print >> log, "-"*79
-  print >> log, get_master_phil().show()
+  print("-"*79, file=log)
+  print(legend, file=log)
+  print("-"*79, file=log)
+  print(get_master_phil().show(), file=log)
 
 def run(args, log):
   args.append('mode=opt')
@@ -64,13 +65,13 @@ def run(args, log):
       print_legend_and_usage(log)
       return
   elif ('--version' in args):
-      print
+      print()
       __version__
       return
-  print >> log, "Computing restraint"
+  print("Computing restraint", file=log)
   cmdline.params.show(out=log, prefix="   ")
   params = cmdline.params.extract()
-  print ""
+  print("")
   print_legend_and_usage(log)
   cmdline = mmtbx.command_line.load_model_and_data(
         args=args,
@@ -92,10 +93,10 @@ def run(args, log):
 
 
 if (__name__ == "__main__"):
-  print "Restraint for Q|R"
+  print("Restraint for Q|R")
   t0 = time.time()
-  print >> log, "Starting Q|R"
-  print >> log,'version: ',__version__
+  print("Starting Q|R", file=log)
+  print('version: ',__version__, file=log)
   run(args=sys.argv[1:], log=log)
-  print >> log, "Time: %6.4f" % (time.time() - t0)
+  print("Time: %6.4f" % (time.time() - t0), file=log)
 

--- a/command_line/status.py
+++ b/command_line/status.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # LIBTBX_SET_DISPATCHER_NAME qr.development.status
 import os, sys
 import time
@@ -15,7 +16,7 @@ file_status = OrderedDict([
   ])
 
 def process_file(filename):
-  print 'process_file',filename
+  print('process_file',filename)
   f=file(filename, 'rb')
   lines = f.read()
   f.close()
@@ -25,7 +26,7 @@ def process_file(filename):
     for lookup, answer in file_status.items():
       if line.find(lookup)>-1:
         done=answer
-  print line
+  print(line)
   return done
 
 def process_dir(d, engine_name='orca'):
@@ -59,8 +60,8 @@ def _cmp_mtime(f1, f2):
 def show_item(files):
   files.sort(_cmp_mtime)
   for f in files:
-    print '  %s : %s' % (f.replace(os.getcwd(), '.'),
-                         time.asctime(time.localtime(os.stat(f).st_mtime)))
+    print('  %s : %s' % (f.replace(os.getcwd(), '.'),
+                         time.asctime(time.localtime(os.stat(f).st_mtime))))
 
 def run(cwd=None):
   if cwd is None:
@@ -69,13 +70,13 @@ def run(cwd=None):
     os.chdir(cwd)
   for root, dirs, files in os.walk(cwd):
     if os.path.basename(root)=='ase_error':
-      print 'ASE error directory exists'
+      print('ASE error directory exists')
     elif root.find('ase_error')>-1:
       pass
     elif root.find('ase')>-1:
       try:
         i = int(os.path.basename(root))
-      except ValueError, e:
+      except ValueError as e:
         i = None
       if i is not None:
         process_dir(root)
@@ -83,36 +84,36 @@ def run(cwd=None):
     if os.path.basename(root)=='pdb':
       check_output_pdbs(root)
 
-  print '_'*80
-  print '\nResults'
-  print '_'*80
-  print
+  print('_'*80)
+  print('\nResults')
+  print('_'*80)
+  print()
   weight_dates = []
   refine_dates = []
   ase_files = []
   for key, item in sorted(results.items()):
     if key in ['restart']:
-      print key
+      print(key)
       show_item([item])
       continue
     if key in ['weight', 'refine', 'refined']:
-      print key
+      print(key)
       show_item(item)
       for f in item:
         if key=='weight': weight_dates.append(os.stat(f).st_mtime)
         if key=='refine': refine_dates.append(os.stat(f).st_mtime)
     else:
       ase_files.append(key)
-  if ase_files: print 'ase'
+  if ase_files: print('ase')
   ase_files.sort(_cmp_mtime)
   for key in ase_files:
-    print '  %s - %s : "%s"' % (key.replace(os.getcwd(),'.'),
+    print('  %s - %s : "%s"' % (key.replace(os.getcwd(),'.'),
                               time.asctime(time.localtime(os.stat(key).st_mtime)),
                               results[key],
-                              )
+                              ))
   if weight_dates and refine_dates:
     if max(weight_dates)>min(refine_dates):
-      print '\n\n  *** refine output models are older than weight models ***\n\n'
+      print('\n\n  *** refine output models are older than weight models ***\n\n')
 
 if __name__=='__main__':
   run(*tuple(sys.argv[1:]))

--- a/command_line/test.py
+++ b/command_line/test.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 # LIBTBX_SET_DISPATCHER_NAME qr.test
 # LIBTBX_SET_DISPATCHER_NAME qr.run_tests
 import sys
@@ -43,22 +44,22 @@ if __name__ == '__main__':
                       help="only tests that don't use MOPAC")
   args = parser.parse_args()
   if (args.unit)      :
-    print >> log,"Running Q|R unit tests"
+    print("Running Q|R unit tests", file=log)
     unit_tests.run(nproc=args.nproc)
   if (args.reg):
-    print >> log,"Running Q|R regression tests"
+    print("Running Q|R regression tests", file=log)
     regression_tests.run(nproc=args.nproc)
   if (args.pdb)       :
-    print >> log,"Running Q|R pdb tests"
+    print("Running Q|R pdb tests", file=log)
     # swith to acceptance_tests.py
     regression_tests.run(args=sys.argv[1:])
   if(args.all):
-    print >> log,"Running all regression tests"
+    print("Running all regression tests", file=log)
     unit_tests.run()
     regression_tests.run()
     regression_tests.run(args=sys.argv[1:])
   if(not args.all and not args.unit and not args.reg and not args.pdb):
-    print >> log,"Running Q|R unit tests"
+    print("Running Q|R unit tests", file=log)
     rc = unit_tests.run(nproc=args.nproc,
                         only_i=args.only,
                         non_mopac_only=args.non_mopac_only)

--- a/completion.py
+++ b/completion.py
@@ -80,7 +80,7 @@ def _add_atom_to_residue_group(atom, ag, icode=None):
   rg.resseq = ag.parent().resseq
   if icode is not None: rg.icode=icode
   rg.append_atom_group(tag)
-  for i, c in enumerate(letters):
+  for i, c in enumerate(ascii_letters):
     if c==ag.parent().parent().id:
       break
   atom.tmp = i

--- a/completion.py
+++ b/completion.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import math
 import sys
 from string import letters
@@ -12,7 +14,7 @@ from iotbx.pdb import amino_acid_codes as aac
 mon_lib_server = server.server()
 get_class = iotbx.pdb.common_residue_names_get_class
 
-from utils import hierarchy_utils
+from qrefine.utils import hierarchy_utils
 from mmtbx.hydrogens.specialised_hydrogen_atoms import conditional_add_cys_hg_to_atom_group
 
 def d_squared(xyz1, xyz2):
@@ -444,7 +446,7 @@ def iterate_over_threes(hierarchy,
     backbone_only=False,
     use_capping_hydrogens=use_capping_hydrogens,
   ):
-    if verbose: print three
+    if verbose: print(three)
     if not len(three): continue
     ptr=0
     assert three.are_linked()
@@ -739,12 +741,12 @@ def _eta_peptide_h(hierarchy,
     ):
     if len(three)==1: continue
     if three[-1].resname!='ETA': continue
-    print three
+    print(three)
     eta = get_residue_group(three[-1])
-    print dir(eta)
+    print(dir(eta))
     previous = get_residue_group(three[-2])
-    print previous
-    print dir(previous)
+    print(previous)
+    print(dir(previous))
     for ag in previous.atom_groups(): # smarter?
       previous_c = ag.get_atom('C')
       previous_o = ag.get_atom('O')
@@ -753,7 +755,7 @@ def _eta_peptide_h(hierarchy,
       if ag.get_atom(atom_name):
         assert 0
       else:
-        for atom in ag.atoms(): print atom.format_atom_record()
+        for atom in ag.atoms(): print(atom.format_atom_record())
         rc = _add_hydrogens_to_atom_group_using_bad(
           ag,
           atom_name,
@@ -767,8 +769,8 @@ def _eta_peptide_h(hierarchy,
           #append_to_end_of_model=append_to_end_of_model,
         )
         assert rc is not None
-        print '-'*80
-        for atom in ag.atoms(): print atom.format_atom_record()
+        print('-'*80)
+        for atom in ag.atoms(): print(atom.format_atom_record())
   #      hierarchy.show()
   #assert 0
 
@@ -935,7 +937,7 @@ def complete_pdb_hierarchy(hierarchy,
       add_hydrogens=False,
     )
     if debug:
-      print 'number of side chains changed',n_changed
+      print('number of side chains changed',n_changed)
       output = hierarchy_utils.write_hierarchy(pdb_filename,
                                                pdb_inp,
                                                ppf.all_chain_proxies.pdb_hierarchy,
@@ -1100,9 +1102,9 @@ def run(pdb_filename=None,
   return ppf.all_chain_proxies.pdb_hierarchy
 
 def display_hierarchy_atoms(hierarchy, n=5):
-  print '-'*80
+  print('-'*80)
   for i, atom in enumerate(hierarchy.atoms()):
-    print atom.quote()
+    print(atom.quote())
     if i>n: break
 
 if __name__=="__main__":

--- a/completion.py
+++ b/completion.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import math
 import sys
-from string import letters
+from string import ascii_letters
 
 import iotbx
 from mmtbx.monomer_library import server

--- a/driver.py
+++ b/driver.py
@@ -275,7 +275,7 @@ class restart_data(object):
     self.rst_data["weights"] = weights
     self.rst_data["conv_test"] = conv_test
     self.rst_data["results"] = results
-    easy_pickle.dump(file_name=rst_file, obj=self.rst_data)
+    # easy_pickle.dump(file_name=rst_file, obj=self.rst_data) #PY3_TODO
 
 class minimizer_ase(object):
   def __init__(self, calculator, params, max_iterations, geometry_rmsd_manager):
@@ -455,7 +455,7 @@ def refine(fmodel,
   elif(not params.refine.skip_weight_search):
     print("Optimal weight search:", file=results.log)
     fmodel_copy = calculator.fmodel.deep_copy()
-    for weight_cycle in xrange(weight_cycle_start,
+    for weight_cycle in range(weight_cycle_start,
                                params.refine.number_of_weight_search_cycles+1):
       if((weight_cycle!=1 and weight_cycle==weight_cycle_start)):
         fmodel = calculator.fmodel.deep_copy()
@@ -479,7 +479,7 @@ def refine(fmodel,
         results      = results)
       # Run minimization
       n_fev = 0
-      for mc in xrange(params.refine.number_of_macro_cycles):
+      for mc in range(params.refine.number_of_macro_cycles):
         minimized = run_minimize(
           calculator            = calculator,
           params                = params,
@@ -558,7 +558,7 @@ def refine(fmodel,
   if(params.refine.skip_weight_search):
     calculator.calculate_weight(verbose=params.debug)
   #
-  for refine_cycle in xrange(refine_cycle_start,
+  for refine_cycle in range(refine_cycle_start,
                       params.refine.number_of_refine_cycles+refine_cycle_start):
     calculator.reset_fmodel(fmodel=fmodel)
     if(clustering):
@@ -573,7 +573,7 @@ def refine(fmodel,
       results      = results)
     #
     n_fev = 0
-    for mc in xrange(params.refine.number_of_macro_cycles):
+    for mc in range(params.refine.number_of_macro_cycles):
       minimized = run_minimize(
         calculator            = calculator,
         params                = params,
@@ -646,7 +646,7 @@ def opt(xray_structure,
     print("\ninteracting pairs number:  ",\
       calculator.restraints_manager.fragments.interacting_pairs, file=results.log)
   results.show(prefix="start")
-  for micro_cycle in xrange(micro_cycle_start,
+  for micro_cycle in range(micro_cycle_start,
                         params.refine.number_of_micro_cycles+micro_cycle_start):
     if(clustering):
       cluster_qm_update.re_clustering(calculator)

--- a/driver.py
+++ b/driver.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import pickle
 import scitbx.lbfgs
@@ -6,7 +8,7 @@ from libtbx import easy_pickle
 from libtbx import adopt_init_args
 from cctbx import xray
 from scitbx.array_family import flex
-import calculator as calculator_module
+from . import calculator as calculator_module
 from libtbx import group_args
 from ase.optimize.lbfgs import LBFGS
 import numpy
@@ -159,8 +161,8 @@ class minimizer(object):
     #    max_value=1.0)
     #  self.x_previous = x_current.deep_copy()
     #
-    print "  step: %3d bond rmsd: %8.6f"%(
-      self.number_of_function_and_gradients_evaluations, self._get_bond_rmsd())
+    print("  step: %3d bond rmsd: %8.6f"%(
+      self.number_of_function_and_gradients_evaluations, self._get_bond_rmsd()))
     return self.calculator.target_and_gradients(x = self.x)
 
   def prcg_min(self,params):
@@ -194,18 +196,18 @@ class minimizer(object):
       gnorm=np.linalg.norm(g)
       # gnorm=self.eg[1].norm()/23.0605480121
       #self.number_of_function_and_gradients_evaluations += 1
-      print 'iter= %i E=%12.5E  G=%0.2f' % (iter+1,e,gnorm)
+      print('iter= %i E=%12.5E  G=%0.2f' % (iter+1,e,gnorm))
       #
       if gnorm <=gconv and iter >1:
-        print 'gnorm pre-convergenced!'
+        print('gnorm pre-convergenced!')
         self.x=flex.double(x_new.tolist())
         break
       #
       if iter<=switch_step:
-        print 'SD step'
+        print('SD step')
         step=-g
       else:
-        print 'CG step'
+        print('CG step')
         gg=g-g_old
         gdgg=np.vdot(g,gg)
         gdg=np.vdot(g_old,g_old)
@@ -239,7 +241,7 @@ class clustering_update(object):
     if(rmsd_diff < self.rmsd_tolerance):
       self.redo_clustering = False
     else:
-      print >> self.log, " rmsd_diff: ", rmsd_diff, "--> need to redo clustering"
+      print(" rmsd_diff: ", rmsd_diff, "--> need to redo clustering", file=self.log)
       self.redo_clustering = True
       self.pre_sites_cart = sites_cart
 
@@ -247,10 +249,10 @@ class clustering_update(object):
     sites_cart = calculator.fmodel.xray_structure.sites_cart()
     rmsd_diff = self.pre_sites_cart.rms_difference(sites_cart)
     if(rmsd_diff > self.rmsd_tolerance):
-      print >> self.log, " rmsd_diff: ", rmsd_diff, "--> need to redo clustering"
+      print(" rmsd_diff: ", rmsd_diff, "--> need to redo clustering", file=self.log)
       calculator.restraints_manager.fragments.set_up_cluster_qm()
-      print >> self.log, " interacting pairs number:  ", \
-        calculator.restraints_manager.fragments.interacting_pairs
+      print(" interacting pairs number:  ", \
+        calculator.restraints_manager.fragments.interacting_pairs, file=self.log)
       self.pre_sites_cart = sites_cart
 
 class restart_data(object):
@@ -287,8 +289,8 @@ class minimizer_ase(object):
     self.number_of_function_and_gradients_evaluations = 0
     self.b_rmsd = self._get_bond_rmsd(
       sites_cart = flex.vec3_double(self.calculator.x))
-    print "  step: %3d bond rmsd: %8.6f"%(
-      self.number_of_function_and_gradients_evaluations, self.b_rmsd)
+    print("  step: %3d bond rmsd: %8.6f"%(
+      self.number_of_function_and_gradients_evaluations, self.b_rmsd))
     self.run(nstep = max_iterations)
     # Syncing and cross-checking begin
     e = 1.e-4
@@ -327,8 +329,8 @@ class minimizer_ase(object):
     #
     self.b_rmsd = self._get_bond_rmsd(
       sites_cart = flex.vec3_double(self.opt.atoms.get_positions()))
-    print "  step: %3d bond rmsd: %8.6f"%(
-      self.number_of_function_and_gradients_evaluations, self.b_rmsd)
+    print("  step: %3d bond rmsd: %8.6f"%(
+      self.number_of_function_and_gradients_evaluations, self.b_rmsd))
     if(self.params.refine.mode=="refine" and
        self.b_rmsd>self.params.refine.max_bond_rmsd and
        self.number_of_function_and_gradients_evaluations>20):
@@ -352,7 +354,7 @@ def run_minimize(calculator, params, results, geometry_rmsd_manager, mode):
       geometry_rmsd_manager = geometry_rmsd_manager,
       mode                  = mode)
   except Exception as e:
-    print "minimization failed:", e
+    print("minimization failed:", e)
     result = None
   return result
 
@@ -418,12 +420,12 @@ def refine(fmodel,
       rst_file_data = pickle.load(handle)
       weight_cycle_start = rst_file_data["weight_cycle"]
       refine_cycle_start = rst_file_data["refine_cycle"]
-      print >> results.log
-      print >> results.log, "*"*50
-      print >> results.log, "restarts from weight_cycle: %d, refine_cycle: %s"%(
-        weight_cycle_start, refine_cycle_start)
-      print >> results.log, "*"*50
-      print >> results.log
+      print(file=results.log)
+      print("*"*50, file=results.log)
+      print("restarts from weight_cycle: %d, refine_cycle: %s"%(
+        weight_cycle_start, refine_cycle_start), file=results.log)
+      print("*"*50, file=results.log)
+      print(file=results.log)
   else:
     weight_cycle_start = 1
     refine_cycle_start = None
@@ -442,26 +444,25 @@ def refine(fmodel,
       rmsd_tolerance = params.refine.rmsd_tolerance * 100,
       verbose=params.debug,
       )
-    print >> results.log, "\ninteracting pairs number:  ", \
-      calculator.restraints_manager.fragments.interacting_pairs
+    print("\ninteracting pairs number:  ", \
+      calculator.restraints_manager.fragments.interacting_pairs, file=results.log)
   weight_cycle = weight_cycle_start
-  print >> results.log, "Start:"
+  print("Start:", file=results.log)
   results.show(prefix="  ")
   if(refine_cycle_start is not None):
-    print >> results.log, \
-     "Found optimal weight. Proceed to further refinement with this weight."
+    print("Found optimal weight. Proceed to further refinement with this weight.", file=results.log)
     fmodel = calculator.fmodel.deep_copy()
   elif(not params.refine.skip_weight_search):
-    print >> results.log, "Optimal weight search:"
+    print("Optimal weight search:", file=results.log)
     fmodel_copy = calculator.fmodel.deep_copy()
     for weight_cycle in xrange(weight_cycle_start,
                                params.refine.number_of_weight_search_cycles+1):
       if((weight_cycle!=1 and weight_cycle==weight_cycle_start)):
         fmodel = calculator.fmodel.deep_copy()
-        if params.debug: print '>>> Using calculator fmodel'
+        if params.debug: print('>>> Using calculator fmodel')
       else:
         fmodel = fmodel_copy.deep_copy()
-        if params.debug: print '>>> Using fmodel_copy fmodel'
+        if params.debug: print('>>> Using fmodel_copy fmodel')
       calculator.reset_fmodel(fmodel = fmodel)
       if(clustering):
         cluster_qm_update.re_clustering(calculator)
@@ -510,7 +511,7 @@ def refine(fmodel,
         fmodel                  = fmodel,
         restraints_weight_scale = calculator.weights.restraints_weight_scale)
       if(is_converged):
-        print >> results.log, "Converged (model)."
+        print("Converged (model).", file=results.log)
         break
       calculator.weights.adjust_restraints_weight_scale(
         fmodel                = fmodel,
@@ -521,11 +522,11 @@ def refine(fmodel,
       is_converged = conv_test.is_weight_scale_converged(
         restraints_weight_scale = calculator.weights.restraints_weight_scale)
       if(is_converged):
-        print >> results.log, "Converged (weight scale)."
+        print("Converged (weight scale).", file=results.log)
         break
       calculator.weights.\
           add_restraints_weight_scale_to_restraints_weight_scales()
-    print >> results.log, "At end of weight search:"
+    print("At end of weight search:", file=results.log)
     results.show(prefix="  ")
     #
     # Done with weight search. Now get best result and refine it further.
@@ -548,9 +549,9 @@ def refine(fmodel,
       geometry_rmsd_manager = geometry_rmsd_manager)
     ####
     # show best
-    print >> results.log, "At start of further refinement:"
+    print("At start of further refinement:", file=results.log)
     results.show(prefix="  ")
-    print >> results.log, "Start further refinement:"
+    print("Start further refinement:", file=results.log)
     refine_cycle_start = 1
   if(refine_cycle_start is None): refine_cycle_start=1
   #
@@ -596,7 +597,7 @@ def refine(fmodel,
       output_file_name   = str(refine_cycle)+"_refine_cycle.pdb")
     results.show(prefix="  ")
     if(conv_test.is_converged(fmodel=fmodel)):
-      print >> results.log, "Converged (model)."
+      print("Converged (model).", file=results.log)
       break
     calculator.weights.adjust_restraints_weight_scale(
       fmodel                = fmodel,
@@ -611,7 +612,7 @@ def refine(fmodel,
       weights      = calculator.weights,
       conv_test    = conv_test,
       results      = results)
-  print >> results.log, "At end of further refinement:"
+  print("At end of further refinement:", file=results.log)
   results.show(prefix="  ")
 
 def opt(xray_structure,
@@ -627,9 +628,9 @@ def opt(xray_structure,
     with open(rst_file, 'rb') as handle:
       rst_file_data = pickle.load(handle)
       micro_cycle_start = rst_file_data["micro_cycle"]
-      print >> results.log, "\n***********************************************************"
-      print >> results.log, "restarts from micro_cycle: %d"%(micro_cycle_start)
-      print >> results.log, "***********************************************************\n"
+      print("\n***********************************************************", file=results.log)
+      print("restarts from micro_cycle: %d"%(micro_cycle_start), file=results.log)
+      print("***********************************************************\n", file=results.log)
       ## check the restart fmodel
       xray_structure = calculator.xray_structure
   else:
@@ -642,8 +643,8 @@ def opt(xray_structure,
     cluster_qm_update = clustering_update(
       calculator.xray_structure.sites_cart(), results.log, \
       params.rmsd_tolerance * 100)
-    print >> results.log, "\ninteracting pairs number:  ",\
-      calculator.restraints_manager.fragments.interacting_pairs
+    print("\ninteracting pairs number:  ",\
+      calculator.restraints_manager.fragments.interacting_pairs, file=results.log)
   results.show(prefix="start")
   for micro_cycle in xrange(micro_cycle_start,
                         params.refine.number_of_micro_cycles+micro_cycle_start):
@@ -678,7 +679,7 @@ def opt(xray_structure,
     results.show(prefix="micro_cycle")
     if(conv_test.is_geometry_converged(
        sites_cart = xray_structure.sites_cart())):
-      print >> results.log, " Convergence at micro_cycle:", micro_cycle
+      print(" Convergence at micro_cycle:", micro_cycle, file=results.log)
       break
     params.refine.pre_opt = None # no pre-optimizations after first macrocycle
   rst_data.write_rst_file(rst_file, micro_cycle=micro_cycle+1,

--- a/driver.py
+++ b/driver.py
@@ -274,8 +274,8 @@ class restart_data(object):
     self.rst_data["rst_xray_structure"] = xray_structure
     self.rst_data["weights"] = weights
     self.rst_data["conv_test"] = conv_test
-    self.rst_data["results"] = results
-    # easy_pickle.dump(file_name=rst_file, obj=self.rst_data) #PY3_TODO
+    # self.rst_data["results"] = results #PY3_TODO ; cannot pickle this
+    easy_pickle.dump(file_name=rst_file, obj=self.rst_data) 
 
 class minimizer_ase(object):
   def __init__(self, calculator, params, max_iterations, geometry_rmsd_manager):

--- a/driver.py
+++ b/driver.py
@@ -274,7 +274,8 @@ class restart_data(object):
     self.rst_data["rst_xray_structure"] = xray_structure
     self.rst_data["weights"] = weights
     self.rst_data["conv_test"] = conv_test
-    # self.rst_data["results"] = results #PY3_TODO ; cannot pickle this
+    # restraints.manager
+    # self.rst_data["results"] = results #PY3_TODO ; cannot serialize '_io.TextIOWrapper' object
     easy_pickle.dump(file_name=rst_file, obj=self.rst_data) 
 
 class minimizer_ase(object):

--- a/finalise.py
+++ b/finalise.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # LIBTBX_SET_DISPATCHER_NAME phenix.development.ready_set
 import os
 import sys
@@ -39,8 +40,8 @@ def remove_alternative_locations(hierarchy):
 
 def run_fetch_pdb(code):
   cmd = 'phenix.fetch_pdb %s' % code
-  print 'Fetching files'
-  print cmd
+  print('Fetching files')
+  print(cmd)
   easy_run.call(cmd)
 
 def loop_over_dir(d):
@@ -48,9 +49,9 @@ def loop_over_dir(d):
   for filename in os.listdir(d):
     if not filename.endswith('.pdb'): continue
     i+=1
-    print '%s\n %3d %s\n%s' % ('*'*80, i, os.path.join(d, filename), '*'*80)
+    print('%s\n %3d %s\n%s' % ('*'*80, i, os.path.join(d, filename), '*'*80))
     if filename in skip:
-      print 'skipping'
+      print('skipping')
       continue
     if os.path.exists(filename.replace('.pdb', '.updated.pdb')):
       run(filename.replace('.pdb', '.updated.pdb'))
@@ -165,7 +166,7 @@ def run(pdb_filename,
       hetero_charges=hetero_charges,
       inter_residue_bonds=inter_residue_bonds,
     )
-    print "total_charge",total_charge
+    print("total_charge",total_charge)
 
   # Idealize H as riding
   params = mmtbx.model.manager.get_default_pdb_interpretation_params()

--- a/fragment.py
+++ b/fragment.py
@@ -188,8 +188,9 @@ class fragments(object):
       size = n_residues,
       maxnum_residues_in_cluster = self.maxnum_residues_in_cluster)
     clusters = self.clustering.get_clusters()
-    self.clusters = sorted(clusters,
-      lambda x, y: 1 if len(x) < len(y) else -1 if len(x) > len(y) else 0)
+    # print(clusters)
+    self.clusters=sorted(clusters, key=len, reverse=True)
+    # print(self.clusters)
     # print "time taken for clustering", (time.time() - t0)
 
   def get_fragments(self):

--- a/fragment.py
+++ b/fragment.py
@@ -290,7 +290,7 @@ class fragments(object):
     overlap_fragments_super = {}
     if(len(phs)>1):
       for i_cluster in range(len(clusters)):
-        for j_ph in xrange(1, len(phs)):
+        for j_ph in range(1, len(phs)):
           fragment_same = (set(fragment_super_atoms_in_phs[0][i_cluster])==
                set(fragment_super_atoms_in_phs[j_ph][i_cluster]))
           # two same fragments for same non-altloc clusters

--- a/fragment.py
+++ b/fragment.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import time
 import copy
@@ -5,12 +7,12 @@ import itertools
 import libtbx.load_env
 from libtbx.utils import Sorry
 from scitbx.array_family import flex
-from utils import fragment_utils
+from .utils import fragment_utils
 from libtbx import group_args
 from qrefine.super_cell import expand
 import qrefine.completion as model_completion
-import completion
-from charges import charges_class
+from . import completion
+from .charges import charges_class
 from mmtbx.pair_interaction import pair_interaction
 
 qrefine = libtbx.env.find_in_repositories("qrefine")
@@ -24,14 +26,14 @@ def check_atoms_integrity(atoms, verbose=False):
       if atom.quote().find('GLY')==-1:
         rc[resid].append(atom.quote())
   for key, item in rc.items():
-    if verbose: print key, item
+    if verbose: print(key, item)
     assert len(item) in [0,2], 'error in cluster %s %s' % (key, item)
 
 def check_selection_integrity(atoms, indices, verbose=False):
   selection = []
   for j in indices:
     atom = atoms[j-1]
-    if verbose: print atom.quote()
+    if verbose: print(atom.quote())
     selection.append(atom)
   check_atoms_integrity(selection, verbose=verbose)
 
@@ -179,7 +181,7 @@ class fragments(object):
         if(len(contain_altlocs)==0):
           new_interaction_list.append(item)
       self.interaction_list = new_interaction_list
-    import clustering
+    from . import clustering
     # t0 = time.time()
     self.clustering = clustering.betweenness_centrality_clustering(
       self.interaction_list,
@@ -255,7 +257,7 @@ class fragments(object):
         fragment_super_atoms_in_ph.append(atoms_in_one_fragment)
         molecules_in_fragments.append(molecules_in_one_fragment)
         if(0):
-          print i, "atoms in cluster: ", atoms_in_one_cluster
+          print(i, "atoms in cluster: ", atoms_in_one_cluster)
         if True:
           atoms = self.pdb_hierarchy_super.atoms()
           check_selection_integrity(atoms, atoms_in_one_cluster)
@@ -495,7 +497,7 @@ def write_mm_charge_file(fragment_extracts, index):
     altlocs.sort()
     if(fragment_extracts.charge_cutoff is not None):
       if(fragment_extracts.debug):
-        print "charge_cutoff: ",fragment_extracts.charge_cutoff
+        print("charge_cutoff: ",fragment_extracts.charge_cutoff)
       xrs_super = fragment_extracts.pdb_hierarchy_super.extract_xray_structure()
       non_fragment_selection_super = xrs_super.selection_within(
         radius=fragment_extracts.charge_cutoff,
@@ -532,7 +534,7 @@ def write_mm_charge_file(fragment_extracts, index):
     sub_working_folder = fragment_extracts.working_folder + "/" + str(index) + "/"
     if (not os.path.isdir(sub_working_folder)):
       os.mkdir(sub_working_folder)
-    if(fragment_extracts.debug): print "write mm pdb file:", index
+    if(fragment_extracts.debug): print("write mm pdb file:", index)
     non_fragment_pdb_file = sub_working_folder + str(index) + "_mm.pdb"
     non_fragment_hierarchy.write_pdb_file(
       file_name=non_fragment_pdb_file,
@@ -623,9 +625,9 @@ def write_cluster_and_fragments_pdbs(fragments,directory):
               crystal_symmetry=F.expansion_cs)
 
   log=open('fragment_info.txt','w')
-  print >> log, '~  # clusters  : ',len(F.cluster_atoms)
-  print >> log, '~  list of atoms per cluster:'
-  print >> log, '~   ',[len(x) for x in F.cluster_atoms]
-  print >> log, '~  list of atoms per fragment:'
-  print >> log, '~   ',[len(x) for x in F.fragment_super_atoms]
+  print('~  # clusters  : ',len(F.cluster_atoms), file=log)
+  print('~  list of atoms per cluster:', file=log)
+  print('~   ',[len(x) for x in F.cluster_atoms], file=log)
+  print('~  list of atoms per fragment:', file=log)
+  print('~   ',[len(x) for x in F.fragment_super_atoms], file=log)
   os.chdir(cwd)

--- a/plugin/ase/ani_qr.py
+++ b/plugin/ase/ani_qr.py
@@ -1,8 +1,10 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import sys
-import ani
-from ani.ase_interface import aniensloader
-from ani.ase_interface import ANIENS
+from . import ani
+from .ani.ase_interface import aniensloader
+from .ani.ase_interface import ANIENS
 import numpy as np
 from ase.calculators.general import Calculator
 
@@ -16,7 +18,7 @@ class Ani(Calculator):
         self.forces = []
 
     def run_qr(self,atoms,coordinates,charge,pointcharges,define_str=None):
-        print " RUNNING ANI"
+        print(" RUNNING ANI")
         self.atoms=atoms
         self.coordinates=coordinates
         self.charge=charge
@@ -30,8 +32,8 @@ class Ani(Calculator):
         force = force.astype(np.float64)
         self.energy_free = energy
         self.forces = force
-        print('Final Energy: ', energy)
-        print('forces are : ',force)
+        print(('Final Energy: ', energy))
+        print(('forces are : ',force))
 	
   
     def get_command(self):

--- a/plugin/ase/gaussian_qr.py
+++ b/plugin/ase/gaussian_qr.py
@@ -17,6 +17,7 @@ University of Science and Technology (KAUST), Saudi Arabia.
 
 See accompanying license files for details.
 """
+from __future__ import print_function
 import os
 
 from ase.calculators.calculator import FileIOCalculator, Parameters, ReadError
@@ -352,5 +353,5 @@ if __name__ == '__main__':
   label = sys.argv[1]
   label = label.replace('.log', '')
   p = Gaussian(label=label)
-  print p
+  print(p)
   p.read_results()

--- a/plugin/ase/mopac_qr.py
+++ b/plugin/ase/mopac_qr.py
@@ -18,7 +18,7 @@ from ase.units import kcal, mol
 from ase.calculators.general import Calculator
 
 str_keys = ['functional', 'job_type']
-int_keys = ['restart', 'spin', 'charge','nproc']
+int_keys = ['restart', 'spin', 'charge']
 bool_keys = ['OPT']
 float_keys = ['RELSCF']
 
@@ -26,6 +26,7 @@ float_keys = ['RELSCF']
 class Mopac(Calculator):
     name = 'MOPAC'
     def __init__(self,
+                nproc=1,
                  label='ase',
                  **kwargs):
         # define parameter fields
@@ -385,4 +386,4 @@ class Mopac(Calculator):
       self.label = label
 
     def set_nproc(self, nproc):
-      self.int_params['nproc'] = nproc
+      self.int_params['nproc'] = int(nproc)

--- a/plugin/ase/mopac_qr.py
+++ b/plugin/ase/mopac_qr.py
@@ -8,6 +8,7 @@ This work is supported by Award No. UK-C0017, made by King Abdullah
 University of Science and Technology (KAUST), Saudi Arabia
 See accompanying license files for details.
 """
+from __future__ import print_function
 import os
 import string
 import numpy as np
@@ -189,7 +190,7 @@ class Mopac(Calculator):
             error='%s exited with error code %i in %s' % (
                            command,exitcode,self.calc_dir)
             stdout,stderr = proc.communicate()
-            print 'shell output: ',stdout,stderr
+            print('shell output: ',stdout,stderr)
             raise RuntimeError(error)
         return 0
 
@@ -208,7 +209,7 @@ class Mopac(Calculator):
           try:
             timer.start()
             stdout,stderr = proc.communicate()
-            print stdout,stderr
+            print(stdout,stderr)
           finally:
             timer.cancel()
 

--- a/plugin/ase/orca_qr.py
+++ b/plugin/ase/orca_qr.py
@@ -3,6 +3,7 @@
 
 
 """
+from __future__ import print_function
 import os
 import string
 import numpy as np

--- a/plugin/ase/pyscf_qr.py
+++ b/plugin/ase/pyscf_qr.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import string
 import numpy as np
@@ -77,8 +78,8 @@ class Pyscf(Calculator):
             self.forces = grad*(-(Hartree/Bohr)/(kcal / unit_mol))
 
             if 0:
-                print" energy", self.energy
-                print "gradients", self.forces
+                print(" energy", self.energy)
+                print("gradients", self.forces)
 
     def read_energy(self, fname):
         return self.energy

--- a/plugin/ase/terachem_qr.py
+++ b/plugin/ase/terachem_qr.py
@@ -2,6 +2,7 @@
 """
   based on ASE script for Mopac
 """
+from __future__ import print_function
 import os
 import string
 import numpy as np
@@ -105,17 +106,18 @@ class TeraChem(Calculator):
         WhatOS=platform.system()
         if "Linux" in WhatOS:
             try:
-	        terachem_library_path = command[0:command.find('bin/terachem')]+"lib"
+                terachem_library_path = command[0:command.find('bin/terachem')] + "lib"
                 if terachem_library_path not in os.environ['LD_LIBRARY_PATH']:
-                    os.environ['LD_LIBRARY_PATH'] +=':'+ terachem_library_path
+                    os.environ[
+                        'LD_LIBRARY_PATH'] += ':' + terachem_library_path
             except Exception as e:
-                print "failed to load terachem library files"       
+                print("failed to load terachem library files")
        
         #print ('%s %s' % (command, finput) + '  >     '+ foutput + '  2>&1')
         #exitcode = os.system('%s %s' % (command, finput) + '  >     '+ foutput + '  2>&1')
         import subprocess
         command = '%s %s' % (command, finput) + '  >     '+ foutput + '  2>&1'
-        print command
+        print(command)
         process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
         process.wait()
         exitcode = process.returncode

--- a/plugin/ase/torchani_qr.py
+++ b/plugin/ase/torchani_qr.py
@@ -14,6 +14,7 @@ We are using the ASE calculator interface:
 https://wiki.fysik.dtu.dk/ase/ase/calculators/calculators.html
 
 """
+from __future__ import print_function
 import os
 import numpy as np
 import torch
@@ -107,9 +108,9 @@ class TorchAni(Calculator):
     self.forces = force.squeeze().numpy().astype(np.float64)
 
     if 0: # we need debugging flag here to switch on and off.
-        print("Torch ANI: ",self.method)
-        print('Energy:',self.energy_free)
-        print('Force:', self.forces)
+        print(("Torch ANI: ",self.method))
+        print(('Energy:',self.energy_free))
+        print(('Force:', self.forces))
 
   def get_command(self):
     """

--- a/plugin/ase/xtb_qr.py
+++ b/plugin/ase/xtb_qr.py
@@ -2,6 +2,7 @@
   based on ASE script for Mopac and then for orca.
 
 """
+from __future__ import print_function
 import os
 import string
 import numpy as np
@@ -61,7 +62,7 @@ class GFNxTB(Calculator):
         from subprocess import Popen, PIPE, STDOUT
         if command == '':
             raise RuntimeError('no command for run_command :(')
-        print 'Running: ', command #debug
+        print('Running: ', command) #debug
         proc = Popen([command], shell=True, stderr=PIPE)
         proc.wait()
         exitcode = proc.returncode

--- a/plugin/ase/xtb_qr.py
+++ b/plugin/ase/xtb_qr.py
@@ -18,6 +18,7 @@ key_parameters = {
                   'charge': None,
                   'method': None,
                   'pointcharges': None,
+                  'nproc': None
                   }
 
 class GFNxTB(Calculator):
@@ -29,7 +30,7 @@ class GFNxTB(Calculator):
                  charge='0',
                  version=2,
                  method='-gfn2',
-                 nproc='1',
+                 nproc=1,
                  atoms=None,
                  pointcharges=None,
                  **kwargs):
@@ -134,13 +135,11 @@ class GFNxTB(Calculator):
           self.pointcharges = os.path.abspath(self.pointcharges)
           self.set_pointcharges()
 
-
         binary = self.command
         if (self.key_parameters['nproc'] > 1):
             nproc=self.key_parameters['nproc']
         else:
             nproc=1
-
 
         command='%s %s --chrg %s --grad %s --parallel %s > xtb.out' % (
                 binary,
@@ -249,4 +248,4 @@ class GFNxTB(Calculator):
       self.label = label
 
     def set_nproc(self, nproc):
-      self.key_parameters['nproc'] = str(nproc)
+      self.key_parameters['nproc'] = int(nproc)

--- a/plugin/tools/qr_tools.py
+++ b/plugin/tools/qr_tools.py
@@ -3,6 +3,7 @@ collection of add-ons for QM calculations.
 contains:
  - gCP
 """
+from __future__ import print_function
 import os
 import sys
 from ase.io import read, write
@@ -18,12 +19,12 @@ def run_command(command):
     from subprocess import Popen, PIPE, STDOUT
     if command == '':
        raise RuntimeError('no command for run_command :(')
-    print 'Running: ', command #debug
+    print('Running: ', command) #debug
     proc = Popen([command], shell=True, stderr=PIPE)
     proc.wait()
     exitcode = proc.returncode
     if exitcode != 0:
-        print exitcode
+        print(exitcode)
         raise RuntimeError(command+' exited with error code')
     return 0
 
@@ -39,7 +40,7 @@ def run_gcp(atoms,level):
             'DFT/pobTZVP', 'TPSS/def2-SVP', 'PW6B95/def2-SVP', 'hf3c', 'pbeh3c','hf/631g']
     avail = [f.lower() for f in avail]
     if level.lower() not in avail:
-             print "Warning: selected gCP level not standard! Beware of what you are doing!" # during development times
+             print("Warning: selected gCP level not standard! Beware of what you are doing!") # during development times
            # raise RuntimeError("""%s. gCP level not avaiable:  %r""" % (level.upper(), avail))
     exe='gcp gcp_tmp.xyz -grad -v -l '+level+' > '+outfile
     run_command(command=exe)
@@ -66,7 +67,7 @@ def read_gcp(outfile,atoms):
                     gradient[j,:3]=tmp[:3]
 
                     
-    print 'E(GCP): ', energy
+    print('E(GCP): ', energy)
     energy*=(Hartree)/(kcal / mol)
     gradient*=(Hartree/Bohr)/(kcal / mol)
     # print gradient
@@ -104,7 +105,7 @@ def read_dftd3(outfile,atoms):
             gradient[j,:3]=tmp[:3]
 
                     
-    print 'E(D3): ', energy
+    print('E(D3): ', energy)
     energy*=(Hartree)/(kcal / mol)
     gradient*=(Hartree/Bohr)/(kcal / mol)
     # print gradient
@@ -128,7 +129,7 @@ def qm_toolbox(atoms,charge,pointcharges,label,addon,addon_method):
     # select helper program 
     # return E/G in kcal/mol/Angstrom
     if 'gcp-d3' in addon.lower():
-        print
+        print()
         egcp,ggcp=run_gcp(atoms,addon_method.split("+")[0])
         ed3,gd3=run_dftd3(atoms,addon_method.split("+")[1])
         energy=egcp+ed3

--- a/plugin/yoink/pyoink.py
+++ b/plugin/yoink/pyoink.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from libtbx.utils import Sorry
 import numpy as np
 try:
@@ -8,8 +9,8 @@ try:
   from jpype import java
   from jpype import startJVM
   import jpype
-except ImportError, e:
-  print str(e)
+except ImportError as e:
+  print(str(e))
   jpype = None
 #  raise Sorry(str(e))
 
@@ -90,7 +91,7 @@ class PYoink(object):
   def write_result(self):
     if(self.out_file==None):
       self.out_file=self.input_file
-    print "self.out_file",self.out_file
+    print("self.out_file",self.out_file)
     self.jaxbFileWriter.write(JString(self.out_file), \
                               self.result.getInput().getValue())
 

--- a/qr.py
+++ b/qr.py
@@ -116,7 +116,7 @@ quantum {
   memory = None
     .type = str
     .help = memory for the QM program
-  nproc = None
+  nproc = 1
     .type = int
     .help = number of parallel processes for the QM program
   qm_addon = gcp dftd3 gcp-d3

--- a/qr.py
+++ b/qr.py
@@ -19,6 +19,8 @@
    and also write our final pdb structure.)
    """
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 import sys
@@ -34,12 +36,12 @@ from libtbx.utils import null_out
 from mmtbx import monomer_library
 import mmtbx.monomer_library.pdb_interpretation
 import mmtbx.restraints
-from fragment import fragments
-import calculator
-import driver
-import restraints
-import cluster_restraints
-import results
+from .fragment import fragments
+from . import calculator
+from . import driver
+from . import restraints
+from . import cluster_restraints
+from . import results
 from qrefine.super_cell import expand
 import mmtbx.model.statistics
 from libtbx import Auto
@@ -271,7 +273,7 @@ def show_cc(map_data, xray_structure, log=None):
     map_data         = map_data,
     crystal_symmetry = xrs.crystal_symmetry())
   d99 = mtriage.get_results().masked.d99
-  if(log is not None): print >> log, "Resolution of map is: %6.4f" %d99
+  if(log is not None): print("Resolution of map is: %6.4f" %d99, file=log)
   result = five_cc(
     map               = map_data,
     xray_structure    = xrs,
@@ -281,8 +283,8 @@ def show_cc(map_data, xray_structure, log=None):
     compute_cc_peaks  = False,
     compute_cc_volume = False).result
   if(log is not None):
-    print >> log, "Map-model correlation coefficient (CC)"
-    print >> log, "  CC_mask  : %6.4f" %result.cc_mask
+    print("Map-model correlation coefficient (CC)", file=log)
+    print("  CC_mask  : %6.4f" %result.cc_mask, file=log)
   return result.cc_mask
 
 def create_fmodel(cmdline, log):
@@ -294,7 +296,7 @@ def create_fmodel(cmdline, log):
   if(cmdline.params.refine.update_all_scales):
     fmodel.update_all_scales(remove_outliers=False)
     fmodel.show(show_header=False, show_approx=False)
-  print >> log, "Initial r_work=%6.4f r_free=%6.4f" % (fmodel.r_work(), fmodel.r_free())
+  print("Initial r_work=%6.4f r_free=%6.4f" % (fmodel.r_work(), fmodel.r_free()), file=log)
   log.flush()
   return fmodel
 
@@ -408,9 +410,9 @@ def validate(model, fmodel, params, rst_file, prefix, log):
   if params.quantum.engine_name=='xtb':
     if params.quantum.method==Auto:
       params.quantum.method=' --gfn 2 --etemp 500 --acc 0.1 --gbsa h2o'
-      print >> log, '  Default method for xtb is %s' % (
+      print('  Default method for xtb is %s' % (
           params.quantum.method,
-          )
+          ), file=log)
       params.quantum.basis = ''
   else:
     if params.quantum.method==Auto:
@@ -420,18 +422,18 @@ def validate(model, fmodel, params, rst_file, prefix, log):
       params.quantum.basis='6-31g'
       outl += '  Setting QM basis to 6-31g\n'
   if outl:
-    print >> log, '\nSetting QM defaults'
-    print >> log, outl
+    print('\nSetting QM defaults', file=log)
+    print(outl, file=log)
 
   if params.quantum.engine_name=='mopac':
     if params.quantum.basis:
-      print >> log, '  Because engine is %s basis set %s ignored' % (
+      print('  Because engine is %s basis set %s ignored' % (
         params.quantum.engine_name,
         params.quantum.basis,
-        )
+        ), file=log)
       params.quantum.basis = ''
     if params.quantum.method=='hf': # default
-      print >> log, '  Default method set as PM7'
+      print('  Default method set as PM7', file=log)
       params.quantum.method='PM7'
 
 
@@ -439,10 +441,10 @@ def run(model, fmodel, map_data, params, rst_file, prefix, log):
   validate(model, fmodel, params, rst_file, prefix, log)
   if(params.cluster.clustering):
     params.refine.gradient_only = True
-    print >> log, " params.gradient_only", params.refine.gradient_only
+    print(" params.gradient_only", params.refine.gradient_only, file=log)
   # RESTART
   if(os.path.isfile(str(rst_file))):
-    print >> log, "restart info is loaded from %s" % params.rst_file
+    print("restart info is loaded from %s" % params.rst_file, file=log)
     rst_data = easy_pickle.load(params.rst_file)
     fmodel = rst_data["fmodel"]
     results_manager = rst_data["results"]
@@ -486,9 +488,9 @@ def run(model, fmodel, map_data, params, rst_file, prefix, log):
         params.output_file_name_prefix + ".rst.pickle")
     if os.path.isfile(params.rst_file):
       os.remove(params.rst_file)
-    print >> log, "\n***********************************************************"
-    print >> log, "restart info will be stored in %s" % params.rst_file
-    print >> log, "***********************************************************\n"
+    print("\n***********************************************************", file=log)
+    print("restart info will be stored in %s" % params.rst_file, file=log)
+    print("***********************************************************\n", file=log)
     start_fmodel = fmodel
     start_ph = None # is it used anywhere? I don't see where it is used!
   if not params.refine.mode=='gtest':
@@ -503,8 +505,8 @@ def run(model, fmodel, map_data, params, rst_file, prefix, log):
   if(params.refine.mode == "gtest"):
     # needs to be moved! Perhaps also to driver
     import numpy as np
-    from fragment import fragment_extracts, write_cluster_and_fragments_pdbs
-    from utils.mathbox import get_grad_mad, get_grad_angle
+    from .fragment import fragment_extracts, write_cluster_and_fragments_pdbs
+    from .utils.mathbox import get_grad_mad, get_grad_angle
 
     # determine what kind of buffer to calculate
     g_mode=[]
@@ -539,28 +541,28 @@ def run(model, fmodel, map_data, params, rst_file, prefix, log):
       clusters=[]
 
     n_grad=len(cluster_scan)*len(g_mode)
-    print >> log, 'Calculating %3i gradients \n' % (n_grad)
-    print >> log, 'Starting loop over different fragment sizes'
+    print('Calculating %3i gradients \n' % (n_grad), file=log)
+    print('Starting loop over different fragment sizes', file=log)
     for ig in g_mode:
 
-      print >> log,'loop for g_mode = %i ' % (ig)
+      print('loop for g_mode = %i ' % (ig), file=log)
       if ig == 2:
-        print >> log, 'pc on'
+        print('pc on', file=log)
         params.cluster.charge_embedding=True
       if ig == 3:
-        print >> log, 'two_buffers on, pc off'
+        print('two_buffers on, pc off', file=log)
         params.cluster.charge_embedding=False
         params.cluster.two_buffers=True
       if ig == 4:
-        print >> log, 'two_buffers on, pc on'
+        print('two_buffers on, pc on', file=log)
         params.cluster.charge_embedding=True
         params.cluster.two_buffers=True
 
       for max_cluster in cluster_scan:
         idl.append([ig,max_cluster])
-        print >> log, 'g_mode: %s' % (" - ".join(map(str,idl[idx])))
+        print('g_mode: %s' % (" - ".join(map(str,idl[idx]))), file=log)
         t0 = time.time()
-        print >> log, "~max cluster size ",max_cluster
+        print("~max cluster size ",max_cluster, file=log)
         params.cluster.maxnum_residues_in_cluster=max_cluster
         fragment_manager = create_fragment_manager(
             params           = params,
@@ -576,13 +578,13 @@ def run(model, fmodel, map_data, params, rst_file, prefix, log):
         rm = restraints_manager
         if(fragment_manager is not None):
           rm = cluster_restraints_manager
-          print "time taken for fragments",(time.time() - t0)
+          print("time taken for fragments",(time.time() - t0))
           frags=fragment_manager
-          print >> log, '~  # clusters  : ',len(frags.clusters)
-          print >> log, '~  list of atoms per cluster:'
-          print >> log, '~   ',[len(x) for x in frags.cluster_atoms]
-          print >> log, '~  list of atoms per fragment:'
-          print >> log, '~   ',[len(x) for x in frags.fragment_super_atoms]
+          print('~  # clusters  : ',len(frags.clusters), file=log)
+          print('~  list of atoms per cluster:', file=log)
+          print('~   ',[len(x) for x in frags.cluster_atoms], file=log)
+          print('~  list of atoms per fragment:', file=log)
+          print('~   ',[len(x) for x in frags.fragment_super_atoms], file=log)
 
           # save fragment data. below works
           # better way is to make a single PDB file with chain IDs
@@ -616,14 +618,14 @@ def run(model, fmodel, map_data, params, rst_file, prefix, log):
           params             = params,
           restraints_manager = rm)
         grad=driver.run_gradient(calculator=calculator_manager)
-        print >> log, '~   gnorm',np.linalg.norm(grad)
-        print >> log, '~   max_g', max(abs(i) for i in grad), ' min_g',min(abs(i) for i in grad)
+        print('~   gnorm',np.linalg.norm(grad), file=log)
+        print('~   max_g', max(abs(i) for i in grad), ' min_g',min(abs(i) for i in grad), file=log)
         name="-".join(map(str,idl[idx]))
         np.save(name,grad)
         idx+=1
-        print >> log, "total time for gradient",(time.time() - t0),'\n\n'
+        print("total time for gradient",(time.time() - t0),'\n\n', file=log)
 
-    print >> log, 'ready to run qr.granalyse!'
+    print('ready to run qr.granalyse!', file=log)
 
   else:
     rm = restraints_manager
@@ -657,7 +659,7 @@ def run(model, fmodel, map_data, params, rst_file, prefix, log):
         log                   = log)
       model = O.run()
       of = open("real_space_refined.pdb", "w")
-      print >> of, model.model_as_pdb(output_cs=True)
+      print(model.model_as_pdb(output_cs=True), file=of)
       of.close()
       model.geometry_statistics(use_hydrogens=False).show()
       show_cc(
@@ -696,17 +698,17 @@ if (__name__ == "__main__"):
   t0 = time.time()
   log = sys.stdout
   args = sys.argv[1:]
-  print >> log, '_'*80
-  print >> log, 'Command line arguments'
+  print('_'*80, file=log)
+  print('Command line arguments', file=log)
   outl = '  '
   for arg in args:
     outl += '"%s"' % arg
-  print >> log, '%s\n' % outl
-  print >> log, '_'*80
+  print('%s\n' % outl, file=log)
+  print('_'*80, file=log)
   cmdline = mmtbx.command_line.load_model_and_data(
       args          = args,
       master_phil   = get_master_phil(),
       create_fmodel = False,
       out           = log)
   run(cmdline=cmdline, log = log)
-  print >> log, "Time: %6.4f"%(time.time()-t0)
+  print("Time: %6.4f"%(time.time()-t0), file=log)

--- a/restraints.py
+++ b/restraints.py
@@ -1,6 +1,8 @@
 from __future__ import division
 from __future__ import absolute_import
 
+from builtins import range
+# from builtins import object
 import os
 import ase.units as ase_units
 import mmtbx.restraints
@@ -128,7 +130,7 @@ class from_expansion(object):
     selection = flex.bool(
       self.pdb_hierarchy_super_completed.atoms().size(), False)
     self.selection = selection.set_selected(
-      flex.size_t(xrange(self.pdb_hierarchy.atoms().size())), True)
+      flex.size_t(range(self.pdb_hierarchy.atoms().size())), True)
     self.restraints_manager = self.restraints_source.update(
       pdb_hierarchy    = self.pdb_hierarchy_super_completed,
       crystal_symmetry = expansion.cs_box)
@@ -174,7 +176,7 @@ class from_altlocs(object):
         force_symmetry           = True,
         log                      = null_out())
       xrs = processed_pdb_file.xray_structure()
-      sctr_keys = xrs.scattering_type_registry().type_count_dict().keys()
+      sctr_keys = list(xrs.scattering_type_registry().type_count_dict().keys())
       has_hd = "H" in sctr_keys or "D" in sctr_keys
       geometry = processed_pdb_file.geometry_restraints_manager(
         show_energies                = False,

--- a/restraints.py
+++ b/restraints.py
@@ -1,19 +1,20 @@
 from __future__ import division
+from __future__ import absolute_import
 
 import os
 import ase.units as ase_units
 import mmtbx.restraints
 from libtbx.utils import Sorry
-from charges import charges_class
+from .charges import charges_class
 from scitbx.array_family import flex
-from plugin.ase.mopac_qr import Mopac
-from plugin.ase.pyscf_qr import Pyscf
-from plugin.ase.terachem_qr import TeraChem
-from plugin.ase.turbomole_qr import Turbomole
-from plugin.ase.orca_qr import Orca
-from plugin.ase.gaussian_qr import Gaussian
-from plugin.ase.xtb_qr import GFNxTB
-from plugin.tools import qr_tools
+from .plugin.ase.mopac_qr import Mopac
+from .plugin.ase.pyscf_qr import Pyscf
+from .plugin.ase.terachem_qr import TeraChem
+from .plugin.ase.turbomole_qr import Turbomole
+from .plugin.ase.orca_qr import Orca
+from .plugin.ase.gaussian_qr import Gaussian
+from .plugin.ase.xtb_qr import GFNxTB
+from .plugin.tools import qr_tools
 from libtbx import group_args
 import math
 from qrefine.super_cell import expand
@@ -319,10 +320,10 @@ class from_qm(object):
     elif(self.qm_engine_name == "gaussian"):
       calculator = Gaussian()
     elif(self.qm_engine_name == "ani"):
-      from plugin.ase.ani_qr import Ani
+      from .plugin.ase.ani_qr import Ani
       calculator = Ani()
     elif(self.qm_engine_name == "torchani"):
-      from plugin.ase.torchani_qr import TorchAni
+      from .plugin.ase.torchani_qr import TorchAni
       calculator = TorchAni(method=self.method)
     elif(self.qm_engine_name == "xtb"):
       calculator = GFNxTB()
@@ -365,9 +366,9 @@ class from_qm(object):
 
   def target_and_gradients(self,sites_cart, selection=None, index=None):
     if(self.clustering):
-      from fragment import get_qm_file_name_and_pdb_hierarchy
-      from fragment import charge
-      from fragment import write_mm_charge_file
+      from .fragment import get_qm_file_name_and_pdb_hierarchy
+      from .fragment import charge
+      from .fragment import write_mm_charge_file
       #
       qm_pdb_file, ph = get_qm_file_name_and_pdb_hierarchy(
                           fragment_extracts=self.fragment_extracts,

--- a/results.py
+++ b/results.py
@@ -100,12 +100,12 @@ class manager(object):
       min_gap = flex.min(gaps)
       index_best = None
       if(filtered_by_gap):
-        for i in xrange(rs.size()):
+        for i in range(rs.size()):
           if(abs(rs[i]-min_r)<1.e-5):
             index_best = i
             break
       else:
-        for i in xrange(gaps.size()):
+        for i in range(gaps.size()):
           if(abs(gaps[i]-min_gap)<1.e-5):
             index_best = i
             break

--- a/results.py
+++ b/results.py
@@ -2,6 +2,7 @@
    needed for logging the results of the refinement.
 """
 from __future__ import division
+from __future__ import print_function
 import os
 import mmtbx.utils
 from scitbx.array_family import flex
@@ -121,14 +122,14 @@ class manager(object):
     if(self.r_works.size()>0):
       fmt="%s %3d Rw: %6.4f Rf: %6.4f Rf-Rw: %6.4f rmsd(b): %7.4f rws: %6.3f n_fev: %d"
       i = self.r_works.size()-1
-      print >> self.log, fmt%(prefix, i, self.r_works[-1], self.r_frees[-1],
+      print(fmt%(prefix, i, self.r_works[-1], self.r_frees[-1],
         self.r_frees[-1]-self.r_works[-1], self.bs[-1],
-        self.restraints_weight_scales[-1], self.n_fev)
+        self.restraints_weight_scales[-1], self.n_fev), file=self.log)
     else:
       fmt="%s %3d rmsd(b): %7.4f rws: %6.3f n_fev: %d"
       i = self.bs.size()-1
-      print >> self.log, fmt%(prefix, i, self.bs[-1],
-        self.restraints_weight_scales[-1], self.n_fev)
+      print(fmt%(prefix, i, self.bs[-1],
+        self.restraints_weight_scales[-1], self.n_fev), file=self.log)
     self.log.flush()
 
   def write_final_pdb_files(self, output_file_name, output_folder_name):
@@ -156,10 +157,10 @@ class manager(object):
     if(self.mode == "refine"):
       xrs_best, r_work, r_free, dummy = self.choose_best(use_r_work=use_r_work)
       if(xrs_best is not None):
-        print >> self.log, "Best r_work: %6.4f r_free: %6.4f"%(r_work, r_free)
+        print("Best r_work: %6.4f r_free: %6.4f"%(r_work, r_free), file=self.log)
       else:
-        print >> self.log, " r_factor (best): None"
-        print >> self.log, " take the last structure"
+        print(" r_factor (best): None", file=self.log)
+        print(" take the last structure", file=self.log)
         self.show(prefix="")
         xrs_best = self.xrss[0]
     if(self.mode == "opt"):
@@ -171,5 +172,5 @@ class manager(object):
     self.write_final_pdb_files(
       output_file_name   = file_name,
       output_folder_name = output_folder_name)
-    print >> self.log, "See %s in %s folder."%(file_name, output_folder_name)
+    print("See %s in %s folder."%(file_name, output_folder_name), file=self.log)
     return xrs_best

--- a/super_cell.py
+++ b/super_cell.py
@@ -122,7 +122,7 @@ def create_super_sphere(pdb_hierarchy,
     ci = get_atom(atoms=rgi.atoms(), name="C")
     ni = get_atom(atoms=rgi.atoms(), name="N")
     if(ci is None or ni is None): # collect non-proteins
-      c = iotbx.pdb.hierarchy.chain(id = all_chains.next())
+      c = iotbx.pdb.hierarchy.chain(id = next(all_chains))
       c.append_residue_group(rgi)
       super_sphere_hierarchy.models()[0].append_chain(c)
       continue
@@ -142,7 +142,7 @@ def create_super_sphere(pdb_hierarchy,
     assert c_linked in [1, 0], c_linked # Either linked or not!
     assert n_linked in [1, 0], n_linked # Either linked or not!
     if(c_linked==0 and n_linked==0): # isolated single residue
-      c = iotbx.pdb.hierarchy.chain(id = all_chains.next())
+      c = iotbx.pdb.hierarchy.chain(id = next(all_chains))
       rgi.link_to_previous=True
       c.append_residue_group(rgi)
       super_sphere_hierarchy.models()[0].append_chain(c)
@@ -157,7 +157,7 @@ def create_super_sphere(pdb_hierarchy,
       n_linked, rgj = grow_chain(residue_groups_k, chunk, ci)
       if(n_linked==1):
         ci = get_atom(atoms=rgj.atoms(), name="C")
-    c = iotbx.pdb.hierarchy.chain(id = all_chains.next())
+    c = iotbx.pdb.hierarchy.chain(id = next(all_chains))
     for i, rg in enumerate(chunk):
       rg.resseq = "%4d" % i
       c.append_residue_group(rg)

--- a/tests/acceptance/subfolders.py
+++ b/tests/acceptance/subfolders.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from os import listdir
 import os
 
@@ -10,7 +11,7 @@ file_names=[]
 for input_file in listdir(root_dir):
     #make a new sub dir for every 1000 files
     file_names.append(input_file)
-print len(file_names)
+print(len(file_names))
 
 folders = []
 for fold_id in range(0,int(len(file_names)/files_per_folder)):
@@ -18,11 +19,11 @@ for fold_id in range(0,int(len(file_names)/files_per_folder)):
    os.mkdir(new_dir+"/"+str(fold_id))
 counter=0
 
-print "number of fodlers",len(folders)
+print("number of fodlers",len(folders))
 for fold in folders:
-   print "folder", fold
+   print("folder", fold)
    for index in range(counter,counter+files_per_folder):
-       print root_dir+"/"+file_names[index]
-       print fold+"/"+file_names[index]
+       print(root_dir+"/"+file_names[index])
+       print(fold+"/"+file_names[index])
        os.rename(root_dir+"/"+file_names[index], fold+"/"+file_names[index])
    counter += files_per_folder

--- a/tests/regression/regression_tests.py
+++ b/tests/regression/regression_tests.py
@@ -1,9 +1,11 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 import time
-from test_reg_01_finalise  import test_finalise
-from test_reg_02_chunk     import test_chunk
-from test_reg_03_restraint import test_restraint
-from test_reg_04_refine    import test_refine
+from .test_reg_01_finalise  import test_finalise
+from .test_reg_02_chunk     import test_chunk
+from .test_reg_03_restraint import test_restraint
+from .test_reg_04_refine    import test_refine
 
 def regression_tests():
   return  {
@@ -16,9 +18,9 @@ def regression_tests():
 def run():
   for name, regression_test in regression_tests().items():
      t0 = time.time()
-     print "Testing: {} ".format(name)
+     print("Testing: {} ".format(name))
      regression_test.run()
-     print "Total time: %6.2f"%(time.time()-t0)
+     print("Total time: %6.2f"%(time.time()-t0))
 
 if(__name__ == "__main__"):
   run()

--- a/tests/regression/restraint_wrapper.py
+++ b/tests/regression/restraint_wrapper.py
@@ -1,11 +1,12 @@
 from __future__ import division
+from __future__ import print_function
 import iotbx.pdb
 from qrefine.restraints import from_qm
 
 class Restraints(object):
 
   def create(self):
-    print " creating "
+    print(" creating ")
     self.pdb_inp = iotbx.pdb.input(self.pdb)
     self.ph = self.pdb_inp.construct_hierarchy()
     self.cs = self.pdb_inp.crystal_symmetry()
@@ -22,7 +23,7 @@ class Restraints(object):
     return Result(self.pdb_code,energy, gradients)
 
   def __call__(self,pdb):
-    print "calling", pdb
+    print("calling", pdb)
     self.pdb= pdb
     self.create(pdb)
     return self.process(pdb)

--- a/tests/regression/test_reg_01_finalise.py
+++ b/tests/regression/test_reg_01_finalise.py
@@ -1,5 +1,6 @@
 from __future__ import division
-from test_reg_00_base import test_base
+from __future__ import absolute_import
+from .test_reg_00_base import test_base
 
 class test_finalise(test_base):
 

--- a/tests/regression/test_reg_02_chunk.py
+++ b/tests/regression/test_reg_02_chunk.py
@@ -1,9 +1,11 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 import libtbx.load_env
-from cluster_wrapper import Clusterer
-from test_reg_00_base import test_base
+from .cluster_wrapper import Clusterer
+from .test_reg_00_base import test_base
 
 qrefine_path = libtbx.env.find_in_repositories("qrefine")
 qr_reg_data = os.path.join(qrefine_path, "tests/regression/datasets/cluster")
@@ -18,7 +20,7 @@ class test_chunk(test_base):
     """
     Exercise to test clustering indices, chunk indices, and the number of atoms in each chunk.
     """
-    print "checking result",result
+    print("checking result",result)
     if self.db.old.find_one({"pdb_code": result.pdb_code}) is None:
       self.insert(result)
     else:

--- a/tests/regression/test_reg_03_restraint.py
+++ b/tests/regression/test_reg_03_restraint.py
@@ -1,8 +1,9 @@
 from __future__ import division
+from __future__ import absolute_import
 import os.path
 import libtbx.load_env
-from restraint_wrapper import Restraints
-from test_reg_00_base import test_base
+from .restraint_wrapper import Restraints
+from .test_reg_00_base import test_base
 
 qrefine_path = libtbx.env.find_in_repositories("qrefine")
 qr_reg_data = os.path.join(qrefine_path, "tests","regression","datasets","cluster")

--- a/tests/regression/test_reg_04_refine.py
+++ b/tests/regression/test_reg_04_refine.py
@@ -1,7 +1,8 @@
 from __future__ import division
+from __future__ import absolute_import
 import os.path
 import libtbx.load_env
-from test_reg_00_base import test_base
+from .test_reg_00_base import test_base
 
 qrefine_path = libtbx.env.find_in_repositories("qrefine")
 qr_path = os.path.join(qrefine_path, "core")

--- a/tests/unit/batch_run_finalise.py
+++ b/tests/unit/batch_run_finalise.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os, sys, shutil
 from libtbx import easy_run
 from multiprocessing import Pool
@@ -19,20 +20,20 @@ def callback(args):
 
 def generate_test_pdb_filenames(d):
   for filename in os.listdir(d):
-    print d, filename
+    print(d, filename)
     if not filename.endswith(".pdb"): continue
     #if len(filename.split('.'))!=2: continue
     #if len(filename.split('.')[0])!=4: continue
     tf = "%s.pdb" % filename[:-4]
-    print tf
+    print(tf)
     shutil.copyfile(os.path.join(d, filename), tf)
     if tf in skip:
-      print '\n\tSKIPPING %s\n' % tf
+      print('\n\tSKIPPING %s\n' % tf)
       continue
     yield tf
 
 def _process_pdb_filename(pdb_file):
-  print '_process_pdb_filename',pdb_file
+  print('_process_pdb_filename',pdb_file)
   complete_file=pdb_file[:-4]+"_complete.pdb"
   rc=0
   if ( pdb_file.endswith("pdb") and not os.path.exists(complete_file) ):
@@ -40,7 +41,7 @@ def _process_pdb_filename(pdb_file):
       pdb_file,
       pdb_file.replace('.pdb', ".log"),
       )
-    print '\n\t~> %s\n' % cmd
+    print('\n\t~> %s\n' % cmd)
     ero = easy_run.fully_buffered(command=cmd)
     err = StringIO()
     ero.show_stderr(out=err)
@@ -59,11 +60,11 @@ def run(folder,
   if nproc>1:
     pool = Pool(processes=nproc)
   for pdb_file in generate_test_pdb_filenames(folder):
-    print pdb_file
+    print(pdb_file)
     if only_code is not None and only_code!=pdb_file.split('.')[0]: continue
     if nproc==1:
       rc, pdb_file = _process_pdb_filename(pdb_file)
-      print 'rc',rc
+      print('rc',rc)
       assert rc==0, 'return code != 0'
     else:
       rc = pool.apply_async(
@@ -81,12 +82,12 @@ def run(folder,
   for pdb_file in pdb_files:
     if "complete.pdb" in pdb_file:
       ok_pdbs.append(pdb_file[:4])
-  print ok_pdbs
-  print results
+  print(ok_pdbs)
+  print(results)
   for pdb, rc in sorted(results.items()):
-    print '-'*80
-    print pdb
-    print rc
+    print('-'*80)
+    print(pdb)
+    print(rc)
   return ok_pdbs
 
 if __name__=="__main__":

--- a/tests/unit/batch_run_finalise.py
+++ b/tests/unit/batch_run_finalise.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import os, sys, shutil
 from libtbx import easy_run
 from multiprocessing import Pool
-from StringIO import StringIO
+from io import StringIO
 import libtbx.load_env
 
 qrefine_path = libtbx.env.find_in_repositories("qrefine")

--- a/tests/unit/run_tests.py
+++ b/tests/unit/run_tests.py
@@ -154,10 +154,10 @@ def run(nproc=6,
     if remove:
       remove.reverse()
       for r in remove:
-        print 'Removing test %s from list' % tests[r]
+        print('Removing test %s from list' % tests[r])
         del tests[r]
-  print "Following tests will be executed:"
-  print " ".join(tests)
+  print("Following tests will be executed:")
+  print(" ".join(tests))
   #
   failed = 0
   in_separate_directory = not(nproc==1)

--- a/tests/unit/run_tests.py
+++ b/tests/unit/run_tests.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 import os
 import time
 import shutil
@@ -16,10 +17,10 @@ qr_unit_tests_data = os.path.join(qr_unit_tests,"data_files")
 
 def assert_folder_is_empty(prefix):
   if(len(os.listdir("."))>0):
-    print '-'*80
-    print "Folder is not empty: test prefix:", prefix
-    print "Remove before proceeding:", os.listdir(".")
-    print '-'*80
+    print('-'*80)
+    print("Folder is not empty: test prefix:", prefix)
+    print("Remove before proceeding:", os.listdir("."))
+    print('-'*80)
     raise Sorry("Folder is not empty: test prefix:", prefix)
 
 def setup_helix_example(pdb_name = "m00_good.pdb",
@@ -56,7 +57,7 @@ def run_cmd(prefix,args,pdb_name = "m00_poor.pdb",
     cmd.append(arg)
   cmd.append("output_folder_name=%s"%test_folder_name)
   cmd.append("> %s.log"%prefix)
-  if(0): print " ".join(cmd)
+  if(0): print(" ".join(cmd))
   return easy_run.go(" ".join(cmd))
 
 def clean_up(prefix, mtz_name = None):
@@ -71,7 +72,7 @@ def clean_up(prefix, mtz_name = None):
   files_to_remove1 = [
     'c_terminal_capping.pdb', 'c_terminal_capping_capping.pdb', 'cluster.xml',
     'helix.pdb', 'helix_complete.pdb', 'helix_readyset_input.pdb', 'qmmm.xml',
-    'test_10_capping.pdb', 'test_cys_hg_capping.pdb',
+    'test_10_capping.pdb', 'test_cys_hg_capping.pdb','test_alt_loc_original.pdb',
     'test_point_charges.pdb', 'q.xyz', "expansion.pdb",
     'test_cys_hg_capping_capping.pdb', 'test_original_pdb.pdb',
     'test_original_pdb_capping.pdb', 'test_short_gap.pdb',
@@ -96,13 +97,13 @@ def runner(function, prefix, disable=False):
   rc = 0
   try:
     if(disable):
-      print prefix + ": Skipped (not recommended, do something about it!)"
+      print(prefix + ": Skipped (not recommended, do something about it!)")
     else:
       t0 = time.time()
       function(prefix = prefix)
-      print prefix + ":  OK  " + "Time: %6.2f (s)" % (time.time() - t0)
+      print(prefix + ":  OK  " + "Time: %6.2f (s)" % (time.time() - t0))
   except Exception as e:
-    print prefix, "FAILED", str(e)
+    print(prefix, "FAILED", str(e))
     traceback.print_exc()
     rc=1
   clean_up(prefix)
@@ -119,7 +120,7 @@ def run(nproc=6,
     nproc=1
   except: only_i=None
   t0=time.time()
-  print 'Running tests on %d processors' % nproc
+  print('Running tests on %d processors' % nproc)
   def _run_test(file_name, in_separate_directory=True):
     if in_separate_directory:
       fn = file_name.split('.')[0]
@@ -166,16 +167,16 @@ def run(nproc=6,
                                                     tests,
                                                     nproc,
                                                     ):
-    print '%sTotal time: %6.2f (s)' % (' '*7, time.time()-t0)
+    print('%sTotal time: %6.2f (s)' % (' '*7, time.time()-t0))
     if err_str:
-      print 'Error output from %s' % args
-      print err_str
-      print '_'*80
+      print('Error output from %s' % args)
+      print(err_str)
+      print('_'*80)
     if res:
-      print '\n\t %s %s\n' % (args,res)
+      print('\n\t %s %s\n' % (args,res))
       failed += 1
   if failed:
-    print 'Failed tests : %d' % failed
+    print('Failed tests : %d' % failed)
     return 1
   return 0
 
@@ -185,8 +186,8 @@ if(__name__ == "__main__"):
   nproc=1
   if args: nproc=int(args[0])
   rc = run(nproc=nproc)
-  print "Total time (all tests): %6.2f"%(time.time()-t0)
+  print("Total time (all tests): %6.2f"%(time.time()-t0))
   if rc:
     assert not rc
   else:
-    print "OK"
+    print("OK")

--- a/tests/unit/run_tests.py
+++ b/tests/unit/run_tests.py
@@ -31,7 +31,7 @@ def setup_helix_example(pdb_name = "m00_good.pdb",
     pdb_name )).xray_structure_simple()
   f_obs = abs(xrs_good.structure_factors(d_min=1.5).f_calc())
   r_free_flags_data = flex.bool()
-  for i in xrange(f_obs.data().size()):
+  for i in range(f_obs.data().size()):
     if(i%10 == 0): r_free_flags_data.append(True)
     else:          r_free_flags_data.append(False)
   r_free_flags = f_obs.array(data = r_free_flags_data)
@@ -57,7 +57,7 @@ def run_cmd(prefix,args,pdb_name = "m00_poor.pdb",
     cmd.append(arg)
   cmd.append("output_folder_name=%s"%test_folder_name)
   cmd.append("> %s.log"%prefix)
-  if(0): print(" ".join(cmd))
+  if(1): print(" ".join(cmd))
   return easy_run.go(" ".join(cmd))
 
 def clean_up(prefix, mtz_name = None):

--- a/tests/unit/tst_00.py
+++ b/tests/unit/tst_00.py
@@ -1,11 +1,12 @@
 from __future__ import division
+from __future__ import absolute_import
 
 import os
 import time
 import iotbx.pdb
 import mmtbx.f_model
 from scitbx.array_family import flex
-import run_tests
+from qrefine.tests.unit import run_tests
 
 def run(prefix):
   """

--- a/tests/unit/tst_01.py
+++ b/tests/unit/tst_01.py
@@ -1,8 +1,9 @@
 from __future__ import division
+from __future__ import absolute_import
 
 import os
 import time
-import run_tests
+from qrefine.tests.unit import run_tests
 import libtbx.load_env
 from mmtbx import monomer_library
 from mmtbx.monomer_library import server

--- a/tests/unit/tst_03.py
+++ b/tests/unit/tst_03.py
@@ -1,9 +1,10 @@
 from __future__ import division
+from __future__ import absolute_import
 
 import os
 import time
 
-import run_tests
+from qrefine.tests.unit import run_tests
 import iotbx.pdb
 import libtbx.load_env
 from libtbx.test_utils import approx_equal

--- a/tests/unit/tst_05.py
+++ b/tests/unit/tst_05.py
@@ -1,7 +1,8 @@
 from __future__ import division
+from __future__ import absolute_import
 
 import time, os
-import run_tests
+from qrefine.tests.unit import run_tests
 
 def run(prefix):
   """

--- a/tests/unit/tst_06.py
+++ b/tests/unit/tst_06.py
@@ -1,7 +1,8 @@
 from __future__ import division
+from __future__ import absolute_import
 
 import time, os
-import run_tests
+from qrefine.tests.unit import run_tests
 import iotbx.pdb
 
 def run(prefix):

--- a/tests/unit/tst_07.py
+++ b/tests/unit/tst_07.py
@@ -29,6 +29,7 @@ def run(prefix):
                                   "qmmm.xml",
                                   ph,
                                   os.path.join(qrefine,"plugin","yoink","dat"))
+
     pyoink=PYoink(os.path.join(qrefine,"plugin","yoink","Yoink-0.0.1.jar"),
                 os.path.join(qrefine,"plugin","yoink","dat"),
                 "cluster.xml")

--- a/tests/unit/tst_07.py
+++ b/tests/unit/tst_07.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import absolute_import
 
 import os
 import time
@@ -6,7 +7,7 @@ import iotbx.pdb
 import libtbx.load_env
 from libtbx.test_utils import approx_equal
 from mmtbx.pair_interaction import pair_interaction
-import run_tests
+from qrefine.tests.unit import run_tests
 
 qrefine = libtbx.env.find_in_repositories("qrefine")
 qr_unit_tests = os.path.join(qrefine, "tests","unit")

--- a/tests/unit/tst_08.py
+++ b/tests/unit/tst_08.py
@@ -1,9 +1,10 @@
 from __future__ import division
+from __future__ import absolute_import
 
 import time, os
 from libtbx.test_utils import approx_equal
 import qrefine.clustering as clustering
-import run_tests
+from qrefine.tests.unit import run_tests
 
 def run(prefix):
   """

--- a/tests/unit/tst_09.py
+++ b/tests/unit/tst_09.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 
 import time
 import os
@@ -7,7 +9,7 @@ import libtbx.load_env
 from libtbx.test_utils import approx_equal
 import iotbx.pdb
 from mmtbx.pair_interaction import pair_interaction
-import run_tests
+from qrefine.tests.unit import run_tests
 
 qrefine = libtbx.env.find_in_repositories("qrefine")
 qr_unit_tests = os.path.join(qrefine, "tests","unit")

--- a/tests/unit/tst_10.py
+++ b/tests/unit/tst_10.py
@@ -1,5 +1,6 @@
 from __future__ import division
 from __future__ import absolute_import
+from __future__ import print_function
 
 import os
 import random
@@ -52,16 +53,17 @@ def run(prefix):
   Exercise combined energy and gradients from cluster qm.
   """
   for restraints in ["cctbx","qm"]:
-    print "Using restraints:", restraints
+    print("Using restraints:", restraints)
     result = []
     for clustering in [True, False]:
-      print "  clustering", clustering, "-"*30
+      print("  clustering", clustering, "-"*30)
       model = get_model()
       if(restraints=="qm"):
         fq = from_qm(
           pdb_hierarchy    = model.get_hierarchy(),
           qm_engine_name   = "mopac",
           method           = "PM3",
+          nproc            = "1",
           crystal_symmetry = model.crystal_symmetry(),
           clustering       = clustering)
       else:

--- a/tests/unit/tst_10.py
+++ b/tests/unit/tst_10.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import absolute_import
 
 import os
 import random
@@ -12,7 +13,7 @@ from qrefine.cluster_restraints import from_cluster
 from qrefine.restraints import from_qm, from_cctbx
 from qrefine.fragment import fragments
 from qrefine.clustering import betweenness_centrality_clustering
-import run_tests
+from qrefine.tests.unit import run_tests
 import mmtbx.model
 from qrefine import qr
 

--- a/tests/unit/tst_11.py
+++ b/tests/unit/tst_11.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 
 import time, os
 import shutil
@@ -6,9 +8,9 @@ from libtbx.test_utils import approx_equal
 from libtbx.utils import Sorry
 import os
 import libtbx.load_env
-import batch_run_finalise
+from qrefine.tests.unit import batch_run_finalise
 from qrefine.tests.unit import skip
-import run_tests
+from qrefine.tests.unit import run_tests
 
 qrefine = libtbx.env.find_in_repositories("qrefine")
 qr_unit_tests = os.path.join(qrefine, "tests","unit")
@@ -75,20 +77,20 @@ def complete_pdbs(expected_list, pdb_dir):
   #input_var = str(
   #  raw_input("run finalise.py for all pdbs in %s will take quite a while (30~60 minutes), continue Y/N : " % pdb_dir))
   if 1: #(input_var == "Y") or 1:
-    print '"%s"' % pdb_dir
+    print('"%s"' % pdb_dir)
     no_error_list = batch_run_finalise.run(pdb_dir,
                                            nproc=1,
                                            #only_code='1il5',
     )
-    print no_error_list
+    print(no_error_list)
     #shutil.rmtree("./tmp")
     expected_list.sort()
     no_error_list.sort()
-    print expected_list
-    print no_error_list
+    print(expected_list)
+    print(no_error_list)
     assert approx_equal(expected_list, no_error_list),'%s has different pdbs passing finalise.py'%pdb_dir
   else:
-    print "skip"
+    print("skip")
 
 if(__name__ == "__main__"):
   prefix = os.path.basename(__file__).replace(".py","")

--- a/tests/unit/tst_12.py
+++ b/tests/unit/tst_12.py
@@ -729,7 +729,7 @@ def test_qxyz_non_zero():
                   'gly',
                   ]:
     tf='%s.pdb' % residue
-    f=file(tf, "wb")
+    f=open(tf, "wb")
     f.write(pdbs[residue])
     f.close()
     pdb_inp = pdb.input(tf)
@@ -741,7 +741,7 @@ def test_qxyz_non_zero():
 
 def test_qxyz_xyzq():
   tf='water.pdb'
-  f=file(tf, "wb")
+  f=open(tf, "wb")
   f.write(pdbs["water"])
   f.close()
   pdb_inp = pdb.input(tf)
@@ -785,7 +785,7 @@ def test_qxyz_xyzq():
 
 def test_terminal_and_alt_loc(residue):
   tf = '%s_terminal.pdb' % residue
-  f=file(tf, "wb")
+  f=open(tf, "wb")
   f.write(pdbs["%s_terminal" % residue])
   f.close()
   assert  qr_repo_parent, 'Set environmental variable %s' % qr_repo_parent_env
@@ -855,7 +855,7 @@ def test_GLY_terminal_charge():
 
 def test_capping_of_C_terminal():
   tf = 'c_terminal_capping.pdb'
-  f=file(tf,'wb')
+  f=open(tf,'wb')
   f.write(pdbs['c_terminal_capping'])
   f.close()
   cmd = 'iotbx.python %s model_completion=False %s' % (
@@ -873,7 +873,7 @@ def test_capping_of_C_terminal():
 
 def test_helix():
   tf = 'helix.pdb'
-  f=file(tf, "wb")
+  f=open(tf, "wb")
   f.write(pdbs["helix"])
   f.close()
   pdb_inp=pdb.input(tf)
@@ -1041,7 +1041,7 @@ def test_capping_of_cluster_complete(only_i=None):
         '%s atom size after babel capping: %d, after run_cluster_complete: %d' %(cluster_file, babel_size, result_size)
 
 def test_short_gap():
-  f=file('test_short_gap.pdb', 'wb')
+  f=open('test_short_gap.pdb', 'wb')
   f.write(pdbs['short_gap'])
   f.close()
   cmd = "phenix.python %s %s model_completion=False" % (
@@ -1054,7 +1054,7 @@ def test_short_gap():
   assert result_size==28
 
 def test_original_pdb():
-  f=file('test_original_pdb.pdb', 'wb')
+  f=open('test_original_pdb.pdb', 'wb')
   f.write(pdbs['2ona_short'])
   f.close()
   cmd = 'phenix.python %s %s %s %s' % (
@@ -1074,7 +1074,7 @@ def test_original_pdb():
   assert len(pdb_inp.atoms())==50
 
 def test_10_capping():
-  f=file('test_10_capping.pdb', 'wb')
+  f=open('test_10_capping.pdb', 'wb')
   f.write(pdbs['10_capping'])
   f.close()
   from qrefine import charges
@@ -1090,7 +1090,7 @@ def test_10_capping():
       )
 
 def _run_go_cmd_on_pdb(code, cmd):
-  f=file('test_%s.pdb' % code, 'wb')
+  f=open('test_%s.pdb' % code, 'wb')
   f.write(pdbs[code])
   f.close()
   cmd += ' %s' % ('test_%s.pdb' % code)

--- a/tests/unit/tst_12.py
+++ b/tests/unit/tst_12.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import time
 import iotbx
@@ -9,7 +11,7 @@ import qrefine.finalise
 import qrefine.charges
 import qrefine.completion
 from qrefine.utils import hierarchy_utils
-import run_tests
+from qrefine.tests.unit import run_tests
 
 ### TODO: after this test works, split it into charge|completion|finalise
 
@@ -816,7 +818,7 @@ def test_1yjp_charge():
   try:
     charge = charges.calculate_pdb_hierarchy_charge(hierarchy)
     assert 0
-  except Exception, e:
+  except Exception as e:
     assert e.message.find('no hydrogens')>-1
   cmd = 'iotbx.python %s/qr-core/finalise.py %s' % (qr_repo_parent, tf)
   easy_run.call(cmd)
@@ -1078,7 +1080,7 @@ def test_10_capping():
   from qrefine import charges
   cc = charges.charges_class('test_10_capping.pdb')
   rc = cc.get_total_charge(list_charges=True)
-  print rc
+  print(rc)
   for test_charge, calculated_charge in zip([0,1,0,0,0,0,-1,0,0,0,0,1,0,0,0,1],
                                             rc,
                                             ):
@@ -1150,11 +1152,11 @@ def run(prefix, nproc=1):
         argss.append((i,p))
   for args, res, errstr in easy_mp.multi_core_run(get_test, argss, nproc):
     if errstr:
-      print '-'*80
-      print args
-      print 'RESULT - ERROR   : %s %s' % (tests[args[0]][0].func_name, args)
-      print errstr
-      print '-'*80
+      print('-'*80)
+      print(args)
+      print('RESULT - ERROR   : %s %s' % (tests[args[0]][0].__name__, args))
+      print(errstr)
+      print('-'*80)
       assert 0
 
 if(__name__ == "__main__"):

--- a/tests/unit/tst_12.py
+++ b/tests/unit/tst_12.py
@@ -730,7 +730,7 @@ def test_qxyz_non_zero():
                   ]:
     tf='%s.pdb' % residue
     f=open(tf, "wb")
-    f.write(pdbs[residue])
+    f.write(pdbs[residue],encoding='utf8')
     f.close()
     pdb_inp = pdb.input(tf)
     hierarchy = pdb_inp.construct_hierarchy()
@@ -742,7 +742,7 @@ def test_qxyz_non_zero():
 def test_qxyz_xyzq():
   tf='water.pdb'
   f=open(tf, "wb")
-  f.write(pdbs["water"])
+  f.write(bytes(pdbs["water"],encoding='utf8'))
   f.close()
   pdb_inp = pdb.input(tf)
   hierarchy = pdb_inp.construct_hierarchy()
@@ -786,7 +786,7 @@ def test_qxyz_xyzq():
 def test_terminal_and_alt_loc(residue):
   tf = '%s_terminal.pdb' % residue
   f=open(tf, "wb")
-  f.write(pdbs["%s_terminal" % residue])
+  f.write(bytes(pdbs["%s_terminal" % residue],encoding='utf8'))
   f.close()
   assert  qr_repo_parent, 'Set environmental variable %s' % qr_repo_parent_env
   cmd = 'iotbx.python %s/qr-core/finalise.py %s' % (qr_repo_parent, tf)
@@ -856,7 +856,7 @@ def test_GLY_terminal_charge():
 def test_capping_of_C_terminal():
   tf = 'c_terminal_capping.pdb'
   f=open(tf,'wb')
-  f.write(pdbs['c_terminal_capping'])
+  f.write(bytes(pdbs['c_terminal_capping'],encoding='utf8'))
   f.close()
   cmd = 'iotbx.python %s model_completion=False %s' % (
     os.path.join(qrefine_d, 'finalise.py'),
@@ -874,7 +874,7 @@ def test_capping_of_C_terminal():
 def test_helix():
   tf = 'helix.pdb'
   f=open(tf, "wb")
-  f.write(pdbs["helix"])
+  f.write(bytes(pdbs["helix"],encoding='utf8'))
   f.close()
   pdb_inp=pdb.input(tf)
   hierarchy = pdb_inp.construct_hierarchy()
@@ -1042,7 +1042,7 @@ def test_capping_of_cluster_complete(only_i=None):
 
 def test_short_gap():
   f=open('test_short_gap.pdb', 'wb')
-  f.write(pdbs['short_gap'])
+  f.write(bytes(pdbs['short_gap'],encoding='utf8'))
   f.close()
   cmd = "phenix.python %s %s model_completion=False" % (
     os.path.join(qrefine_d, 'completion.py'),
@@ -1055,7 +1055,7 @@ def test_short_gap():
 
 def test_original_pdb():
   f=open('test_original_pdb.pdb', 'wb')
-  f.write(pdbs['2ona_short'])
+  f.write(bytes(pdbs['2ona_short'],encoding='utf8'))
   f.close()
   cmd = 'phenix.python %s %s %s %s' % (
     os.path.join(qrefine_d, 'completion.py'),
@@ -1075,7 +1075,7 @@ def test_original_pdb():
 
 def test_10_capping():
   f=open('test_10_capping.pdb', 'wb')
-  f.write(pdbs['10_capping'])
+  f.write(bytes(pdbs['10_capping'],encoding='utf8'))
   f.close()
   from qrefine import charges
   cc = charges.charges_class('test_10_capping.pdb')
@@ -1091,7 +1091,7 @@ def test_10_capping():
 
 def _run_go_cmd_on_pdb(code, cmd):
   f=open('test_%s.pdb' % code, 'wb')
-  f.write(pdbs[code])
+  f.write(bytes(pdbs[code],encoding='utf8'))
   f.close()
   cmd += ' %s' % ('test_%s.pdb' % code)
   rc = easy_run.go(cmd)

--- a/tests/unit/tst_12.py
+++ b/tests/unit/tst_12.py
@@ -721,7 +721,7 @@ HETATM   55 HD23 DLE A   4       5.391  -8.150  12.314  0.00 38.38           H
 
 def test_qxyz_non_zero():
   def _check_non_zero_charge(filename):
-    for line in open(filename, 'rb').readlines():
+    for line in open(filename, 'r').readlines():
       tmp = line.split()
       if len(tmp)<2: continue
       assert float(tmp[0])!=0, 'no partial charge %s' % line
@@ -729,8 +729,8 @@ def test_qxyz_non_zero():
                   'gly',
                   ]:
     tf='%s.pdb' % residue
-    f=open(tf, "wb")
-    f.write(pdbs[residue],encoding='utf8')
+    f=open(tf, "w")
+    f.write(pdbs[residue])
     f.close()
     pdb_inp = pdb.input(tf)
     hierarchy = pdb_inp.construct_hierarchy()
@@ -741,8 +741,8 @@ def test_qxyz_non_zero():
 
 def test_qxyz_xyzq():
   tf='water.pdb'
-  f=open(tf, "wb")
-  f.write(bytes(pdbs["water"],encoding='utf8'))
+  f=open(tf, "w")
+  f.write(pdbs["water"])
   f.close()
   pdb_inp = pdb.input(tf)
   hierarchy = pdb_inp.construct_hierarchy()
@@ -762,7 +762,7 @@ def test_qxyz_xyzq():
 0.204  0.733  0.0  -0.296
 0.204  -0.524  0.0  0.593
 '''
-  lines = open('test_water.dat', 'rb').read()
+  lines = open('test_water.dat', 'r').read()
   lines = lines.strip().replace('\n','').replace(' ','')
   tst_str = tst_str.strip().replace('\n','').replace(' ','')
   #for a,b in zip(lines.strip(), tst_str.strip()): print '"%s" "%s"' % (a,b)
@@ -777,7 +777,7 @@ def test_qxyz_xyzq():
 -0.21  0.0  -0.296  -0.408
 0.733  0.0  -0.296  0.204
 -0.524  0.0  0.593  0.204'''
-  lines = open('test_water.dat', 'rb').read()
+  lines = open('test_water.dat', 'r').read()
   lines = lines.strip().replace('\n','').replace(' ','')
   tst_str = tst_str.strip().replace('\n','').replace(' ','')
   assert lines.strip()==tst_str, '%s'% (lines)
@@ -785,8 +785,8 @@ def test_qxyz_xyzq():
 
 def test_terminal_and_alt_loc(residue):
   tf = '%s_terminal.pdb' % residue
-  f=open(tf, "wb")
-  f.write(bytes(pdbs["%s_terminal" % residue],encoding='utf8'))
+  f=open(tf, "w")
+  f.write(pdbs["%s_terminal" % residue])
   f.close()
   assert  qr_repo_parent, 'Set environmental variable %s' % qr_repo_parent_env
   cmd = 'iotbx.python %s/qr-core/finalise.py %s' % (qr_repo_parent, tf)
@@ -855,8 +855,8 @@ def test_GLY_terminal_charge():
 
 def test_capping_of_C_terminal():
   tf = 'c_terminal_capping.pdb'
-  f=open(tf,'wb')
-  f.write(bytes(pdbs['c_terminal_capping'],encoding='utf8'))
+  f=open(tf,'w')
+  f.write(pdbs['c_terminal_capping'])
   f.close()
   cmd = 'iotbx.python %s model_completion=False %s' % (
     os.path.join(qrefine_d, 'finalise.py'),
@@ -873,8 +873,8 @@ def test_capping_of_C_terminal():
 
 def test_helix():
   tf = 'helix.pdb'
-  f=open(tf, "wb")
-  f.write(bytes(pdbs["helix"],encoding='utf8'))
+  f=open(tf, "w")
+  f.write(pdbs["helix"])
   f.close()
   pdb_inp=pdb.input(tf)
   hierarchy = pdb_inp.construct_hierarchy()
@@ -1041,8 +1041,9 @@ def test_capping_of_cluster_complete(only_i=None):
         '%s atom size after babel capping: %d, after run_cluster_complete: %d' %(cluster_file, babel_size, result_size)
 
 def test_short_gap():
-  f=open('test_short_gap.pdb', 'wb')
-  f.write(bytes(pdbs['short_gap'],encoding='utf8'))
+  f=open('test_short_gap.pdb', 'w')
+  f.write(pdbs['short_gap'])
+  # f.write(bytes(pdbs['short_gap'],encoding='utf8'))
   f.close()
   cmd = "phenix.python %s %s model_completion=False" % (
     os.path.join(qrefine_d, 'completion.py'),
@@ -1054,8 +1055,8 @@ def test_short_gap():
   assert result_size==28
 
 def test_original_pdb():
-  f=open('test_original_pdb.pdb', 'wb')
-  f.write(bytes(pdbs['2ona_short'],encoding='utf8'))
+  f=open('test_original_pdb.pdb', 'w')
+  f.write(pdbs['2ona_short'])
   f.close()
   cmd = 'phenix.python %s %s %s %s' % (
     os.path.join(qrefine_d, 'completion.py'),
@@ -1074,8 +1075,8 @@ def test_original_pdb():
   assert len(pdb_inp.atoms())==50
 
 def test_10_capping():
-  f=open('test_10_capping.pdb', 'wb')
-  f.write(bytes(pdbs['10_capping'],encoding='utf8'))
+  f=open('test_10_capping.pdb', 'w')
+  f.write(pdbs['10_capping'],encoding='utf8')
   f.close()
   from qrefine import charges
   cc = charges.charges_class('test_10_capping.pdb')
@@ -1090,8 +1091,8 @@ def test_10_capping():
       )
 
 def _run_go_cmd_on_pdb(code, cmd):
-  f=open('test_%s.pdb' % code, 'wb')
-  f.write(bytes(pdbs[code],encoding='utf8'))
+  f=open('test_%s.pdb' % code, 'w')
+  f.write(pdbs[code])
   f.close()
   cmd += ' %s' % ('test_%s.pdb' % code)
   rc = easy_run.go(cmd)

--- a/tests/unit/tst_13.py
+++ b/tests/unit/tst_13.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 import sys
@@ -9,7 +11,7 @@ import iotbx.pdb
 import mmtbx.command_line
 import libtbx.load_env
 from libtbx.test_utils import approx_equal
-import run_tests
+from qrefine.tests.unit import run_tests
 
 from ase.io import write
 from ase.io import read as ase_io_read
@@ -50,7 +52,7 @@ def approx_equal2(v1,v2,tol):
   for i in range(v1.shape[0]):
     error=abs(v1[i]-v2[i])
     if( error>=vtol[i] ):
-      print 'oh dear!',i,error,vtol[i]
+      print('oh dear!',i,error,vtol[i])
       happy_bob=False
   return happy_bob
 

--- a/tests/unit/tst_14.py
+++ b/tests/unit/tst_14.py
@@ -1,10 +1,12 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 
 import time, os
 import iotbx.pdb
 from qrefine import super_cell
 from libtbx.test_utils import approx_equal
-import run_tests
+from qrefine.tests.unit import run_tests
 
 pdb_str = """
 CRYST1   10.000   10.000   10.000  90.00  90.00  90.00 P 1
@@ -33,7 +35,7 @@ def run(prefix):
   Exercise supercell.
   """
   of = open("%s.pdb"%prefix,"w")
-  print >> of, pdb_str
+  print(pdb_str, file=of)
   of.close()
   pdb_inp = iotbx.pdb.input(source_info=None, lines=pdb_str)
   ph = pdb_inp.construct_hierarchy()

--- a/tests/unit/tst_15.py
+++ b/tests/unit/tst_15.py
@@ -1,10 +1,12 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import iotbx.pdb
 from scitbx.array_family import flex
 from libtbx import easy_pickle
 import time
-import run_tests
+from qrefine.tests.unit import run_tests
 import libtbx.load_env
 from libtbx.test_utils import approx_equal
 
@@ -54,8 +56,8 @@ def run(prefix):
         diff = g1-g2
         if(0):
           for i, diff_i in enumerate(diff):
-            print i+1, diff_i, g1[i], g2[i]
-          print
+            print(i+1, diff_i, g1[i], g2[i])
+          print()
         assert approx_equal(flex.max(diff), 0, 1.0E-4)
       else:
         ## loose comparison

--- a/tests/unit/tst_16.py
+++ b/tests/unit/tst_16.py
@@ -42,8 +42,7 @@ def run(prefix):
     if(0):
       for i, diff_i in enumerate(diff):
         if(abs(max(diff_i)) > 1.e-6):
-        print(i, diff_i, g1[i], g2[i])
-    print()
+           print(i, diff_i, g1[i], g2[i])
     assert approx_equal(diff.max(), [0,0,0])
 
 if(__name__ == '__main__'):

--- a/tests/unit/tst_16.py
+++ b/tests/unit/tst_16.py
@@ -1,10 +1,12 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 import iotbx.pdb
 import os
 from scitbx.array_family import flex
 from libtbx import easy_pickle
 import time
-import run_tests
+from qrefine.tests.unit import run_tests
 from libtbx.test_utils import approx_equal
 import libtbx.load_env
 
@@ -40,8 +42,8 @@ def run(prefix):
     if(0):
       for i, diff_i in enumerate(diff):
         if(abs(max(diff_i)) > 1.e-6):
-          print i, diff_i, g1[i], g2[i]
-      print
+        print(i, diff_i, g1[i], g2[i])
+    print()
     assert approx_equal(diff.max(), [0,0,0])
 
 if(__name__ == '__main__'):

--- a/tests/unit/tst_17.py
+++ b/tests/unit/tst_17.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 
 import time, os
 import iotbx.pdb
@@ -15,7 +17,7 @@ import mmtbx.monomer_library.pdb_interpretation
 import mmtbx.restraints
 from mmtbx import monomer_library
 import libtbx.load_env
-import run_tests
+from qrefine.tests.unit import run_tests
 
 mon_lib_srv = mmtbx.monomer_library.server.server()
 ener_lib    = mmtbx.monomer_library.server.ener_lib()
@@ -118,9 +120,9 @@ def run3(prefix):
   diff = g1-g2
   assert approx_equal(diff.max(), [0,0,0])
   if(0):
-    print diff.max()
+    print(diff.max())
     for d in diff:
-      print d
+      print(d)
 
 def run2(prefix):
   file_name=os.path.join(qr_unit_tests_data,"h_altconf.pdb")
@@ -165,9 +167,9 @@ def run2(prefix):
   diff = g1-g2
   assert approx_equal(diff.max(), [0,0,0])
   if(0):
-    print diff.max()
+    print(diff.max())
     for d in diff:
-      print d
+      print(d)
 
 def run1(prefix):
   pdb_inp = iotbx.pdb.input(file_name=os.path.join(qr_unit_tests_data,"m.pdb"))
@@ -178,17 +180,17 @@ def run1(prefix):
   #
   asc = ph.atom_selection_cache()
   sA = asc.selection("altloc A or altloc ' '")
-  if 0: print sA.count(True)
+  if 0: print(sA.count(True))
   phA = ph.select(sA)
   phA.write_pdb_file("A.pdb")
 
   sB = asc.selection("altloc B or altloc ' '")
-  if 0: print sB.count(True)
+  if 0: print(sB.count(True))
   phB = ph.select(sB)
   phB.write_pdb_file("B.pdb")
 
   sW  = asc.selection("altloc ' '")
-  if 0: print sW.count(True)
+  if 0: print(sW.count(True))
   phW = ph.select(sW)
   phW.write_pdb_file("W.pdb")
   #
@@ -205,24 +207,24 @@ def run1(prefix):
     compute_gradients=True)
   #
   if 0:
-    print list(phW.atoms())[0].name
-    print esW.gradients[0]
-    print
+    print(list(phW.atoms())[0].name)
+    print(esW.gradients[0])
+    print()
 
-    print list(ph.atoms())[0].name
-    print es.gradients[0]
-    print esA.gradients[0]
-    print esB.gradients[0]
-    print
-    print list(phA.atoms())[5].name, list(ph.atoms())[5].name
-    print es.gradients[5]
-    print esA.gradients[5]
-    print
-    print list(phB.atoms())[5].name, list(ph.atoms())[12].name
-    print es.gradients[12]
-    print esB.gradients[5]
-    print
-    print "-------"
+    print(list(ph.atoms())[0].name)
+    print(es.gradients[0])
+    print(esA.gradients[0])
+    print(esB.gradients[0])
+    print()
+    print(list(phA.atoms())[5].name, list(ph.atoms())[5].name)
+    print(es.gradients[5])
+    print(esA.gradients[5])
+    print()
+    print(list(phB.atoms())[5].name, list(ph.atoms())[12].name)
+    print(es.gradients[12])
+    print(esB.gradients[5])
+    print()
+    print("-------")
   result = list(flex.double(esA.gradients[0])+
                 flex.double(esB.gradients[0])-
                 flex.double(esW.gradients[0]))

--- a/tests/unit/tst_18.py
+++ b/tests/unit/tst_18.py
@@ -1,10 +1,12 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 import iotbx.pdb
 import os
 from scitbx.array_family import flex
 from libtbx import easy_pickle
 import time
-import run_tests
+from qrefine.tests.unit import run_tests
 from libtbx.test_utils import approx_equal
 import libtbx.load_env
 

--- a/tests/unit/tst_19.py
+++ b/tests/unit/tst_19.py
@@ -1,10 +1,11 @@
 from __future__ import division
+from __future__ import absolute_import
 import iotbx.pdb
 import os
 from scitbx.array_family import flex
 from libtbx import easy_pickle
 import time
-import run_tests
+from qrefine.tests.unit import run_tests
 from libtbx.test_utils import approx_equal
 import libtbx.load_env
 

--- a/tests/unit/tst_20.py
+++ b/tests/unit/tst_20.py
@@ -1,10 +1,11 @@
 from __future__ import division
+from __future__ import absolute_import
 import iotbx.pdb
 import os
 import time
 import libtbx.load_env
 from qrefine.super_cell import expand
-import run_tests
+from qrefine.tests.unit import run_tests
 
 qrefine = libtbx.env.find_in_repositories("qrefine")
 qr_unit_tests_data = os.path.join(qrefine,"tests","unit","data_files")

--- a/tests/unit/tst_21.py
+++ b/tests/unit/tst_21.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 import  iotbx.pdb
 import time
 import sys
 import os
 
-import run_tests
+from qrefine.tests.unit import run_tests
 
 pdb_lines = '''
 CRYST1  100.846  117.207  186.414  90.00  90.00  90.00 P 1

--- a/tests/unit/tst_21.py
+++ b/tests/unit/tst_21.py
@@ -1851,8 +1851,8 @@ if(__name__ == "__main__"):
   t0 = time.time()
   args = sys.argv[1:]
   if len(args)==0:
-    f=file('test_point_charges.pdb', 'wb')
-    f.write(pdb_lines)
+    f=open('test_point_charges.pdb', 'wb')
+    f.write(bytes(pdb_lines,encoding='utf8'))
     f.close()
     args = ['test_point_charges.pdb']
   run(args[0], log)

--- a/tests/unit/tst_22.py
+++ b/tests/unit/tst_22.py
@@ -1,8 +1,10 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import time
 import libtbx.load_env
-import run_tests
+from qrefine.tests.unit import run_tests
 from libtbx import easy_run
 
 qrefine = libtbx.env.find_in_repositories("qrefine")
@@ -14,7 +16,7 @@ def run(prefix):
   """
   pdb_name = os.path.join(qr_unit_tests_data, "tst_22.pdb")
   cmd = "qr.charges %s verbose=False"%pdb_name
-  if(0): print cmd
+  if(0): print(cmd)
   r = easy_run.go(cmd)
   # Make sure no
   assert len(r.stderr_lines)==0, r.stderr_lines

--- a/tests/unit/tst_23.py
+++ b/tests/unit/tst_23.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import
 import os, sys
-import run_tests
+from qrefine.tests.unit import run_tests
 from qrefine.charges import charges_class
 
 def get_charge(fn, assert_correct_chain_terminii=True):

--- a/tests/unit/tst_23.py
+++ b/tests/unit/tst_23.py
@@ -117,8 +117,8 @@ def run(prefix):
     for action, lines in item.items():
       #print code, action,
       fn = '%s_%s.pdb' % (code, action)
-      f=file(fn, 'wb')
-      f.write(lines)
+      f=open(fn, "wb")
+      f.write(bytes(lines,encoding='utf8'))
       f.close()
       cmd = 'qr.charges verbose=True assert_correct_chain_terminii=False'
       cmd += ' %s' % fn

--- a/tests/unit/tst_24.py
+++ b/tests/unit/tst_24.py
@@ -1,5 +1,7 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os, sys
-import run_tests
+from qrefine.tests.unit import run_tests
 from libtbx import easy_run
 import libtbx.load_env
 
@@ -33,7 +35,7 @@ def run(prefix):
   f.write(pdb_lines)
   f.close()
   cmd = 'qr.finalise %s action="capping"' % (fn)
-  if 0: print cmd
+  if 0: print(cmd)
   rc = easy_run.go(cmd)
   os.remove(fn)
   fnc = '%s_capping.pdb' % fn.replace('.pdb','')
@@ -42,7 +44,7 @@ def run(prefix):
   f.close()
   assert ' HG  CYS A  78' not in lines
   cmd = 'qr.charges %s verbose=1' % (fnc)
-  if 0: print cmd
+  if 0: print(cmd)
   rc = easy_run.go(cmd)
   assert 'Charge: 0' in rc.stdout_lines
   os.remove(fnc)

--- a/tests/unit/tst_24.py
+++ b/tests/unit/tst_24.py
@@ -31,16 +31,16 @@ ANISOU 1832 CU    CU A 201      503   1903    690    -55    119      0      Cu
 
 def run(prefix):
   fn='test_cu_cys.pdb'
-  f=file(fn, 'wb')
-  f.write(pdb_lines)
+  f=open(fn, 'wb')
+  f.write(bytes(pdb_lines,encoding='utf8'))
   f.close()
   cmd = 'qr.finalise %s action="capping"' % (fn)
   if 0: print(cmd)
   rc = easy_run.go(cmd)
   os.remove(fn)
   fnc = '%s_capping.pdb' % fn.replace('.pdb','')
-  f=file(fnc, 'rb')
-  lines=f.read()
+  f=open(fnc, 'rb')
+  lines=f.read().decode('utf8')
   f.close()
   assert ' HG  CYS A  78' not in lines
   cmd = 'qr.charges %s verbose=1' % (fnc)

--- a/tests/unit/tst_25.py
+++ b/tests/unit/tst_25.py
@@ -327,15 +327,13 @@ TER
 
 def run(prefix):
   fn='expansion.pdb'
-  f=open(fn, 'wb')
-  f.write(bytes(expansion,encoding='utf8'))
-  f.close()
+  with open(fn, 'w') as f:
+    f.write(expansion)
   fn='test_alt_loc_original.pdb'
-  f=open(fn, 'wb')
-  f.write(bytes(pdb_lines,encoding='utf8'))
-  f.close()
-  cmd = 'phenix.python %s/completion.py %s model_completion=False original_pdb_filename=expansion.pdb' % (qrefine_path, fn)
-  if 0: print(cmd)
+  with open(fn, 'w') as f:
+    f.write(pdb_lines)
+  cmd = 'python %s/completion.py %s model_completion=False original_pdb_filename=expansion.pdb' % (qrefine_path, fn)
+  if 1: print(cmd)
   easy_run.go(cmd)
   fnc = '%s_capping.pdb' % fn.replace('.pdb','')
   cmd = 'phenix.pdb_interpretation %s' % fnc

--- a/tests/unit/tst_25.py
+++ b/tests/unit/tst_25.py
@@ -1,5 +1,7 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os, sys
-import run_tests
+from qrefine.tests.unit import run_tests
 from libtbx import easy_run
 import libtbx.load_env
 
@@ -333,11 +335,11 @@ def run(prefix):
   f.write(pdb_lines)
   f.close()
   cmd = 'phenix.python %s/completion.py %s model_completion=False original_pdb_filename=expansion.pdb' % (qrefine_path, fn)
-  if 0: print cmd
+  if 0: print(cmd)
   easy_run.go(cmd)
   fnc = '%s_capping.pdb' % fn.replace('.pdb','')
   cmd = 'phenix.pdb_interpretation %s' % fnc
-  if 0: print cmd
+  if 0: print(cmd)
   rc = easy_run.go(cmd)
   assert '     H      47      1.00' in rc.stdout_lines
   os.remove(fn)

--- a/tests/unit/tst_25.py
+++ b/tests/unit/tst_25.py
@@ -327,12 +327,12 @@ TER
 
 def run(prefix):
   fn='expansion.pdb'
-  f=file(fn, 'wb')
-  f.write(expansion)
+  f=open(fn, 'wb')
+  f.write(bytes(expansion,encoding='utf8'))
   f.close()
   fn='test_alt_loc_original.pdb'
-  f=file(fn, 'wb')
-  f.write(pdb_lines)
+  f=open(fn, 'wb')
+  f.write(bytes(pdb_lines,encoding='utf8'))
   f.close()
   cmd = 'phenix.python %s/completion.py %s model_completion=False original_pdb_filename=expansion.pdb' % (qrefine_path, fn)
   if 0: print(cmd)

--- a/tests/unit/tst_26.py
+++ b/tests/unit/tst_26.py
@@ -32,8 +32,8 @@ TER
 
 def run(prefix):
   fn='test_zn_his_charge.pdb'
-  f=file(fn, 'wb')
-  f.write(pdb_lines)
+  f=open(fn, 'wb')
+  f.write(bytes(pdb_lines,encoding='utf8'))
   f.close()
   cmd = 'qr.charges %s verbose=1' % (fn)
   if 0: print(cmd)

--- a/tests/unit/tst_26.py
+++ b/tests/unit/tst_26.py
@@ -1,5 +1,7 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os, sys
-import run_tests
+from qrefine.tests.unit import run_tests
 from libtbx import easy_run
 import libtbx.load_env
 
@@ -34,7 +36,7 @@ def run(prefix):
   f.write(pdb_lines)
   f.close()
   cmd = 'qr.charges %s verbose=1' % (fn)
-  if 0: print cmd
+  if 0: print(cmd)
   rc = easy_run.go(cmd)
   assert 'Charge: 0' in rc.stdout_lines
   os.remove(fn)

--- a/tests/unit/tst_27.py
+++ b/tests/unit/tst_27.py
@@ -1,5 +1,7 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os, sys
-import run_tests
+from qrefine.tests.unit import run_tests
 from libtbx import easy_run
 import libtbx.load_env
 
@@ -562,7 +564,7 @@ def run(prefix):
   f.write(pdb_lines)
   f.close()
   cmd = 'qr.finalise %s action="capping"' % (fn)
-  if 0: print cmd
+  if 0: print(cmd)
   rc = easy_run.go(cmd)
   os.remove(fn)
   fnc = '%s_capping.pdb' % fn.replace('.pdb','')
@@ -579,7 +581,7 @@ def run(prefix):
     assert line not in lines, 'found %s' % line
   assert ' HE  ARG A  10' in lines, 'not found HE  ARG A  10'
   cmd = 'qr.charges %s verbose=1' % (fnc)
-  if 0: print cmd
+  if 0: print(cmd)
   rc = easy_run.go(cmd)
   assert 'Charge: -1' in rc.stdout_lines
   os.remove(fnc)

--- a/tests/unit/tst_27.py
+++ b/tests/unit/tst_27.py
@@ -560,16 +560,16 @@ TER
 
 def run(prefix):
   fn='test_remove_hg_from_zn_cys.pdb'
-  f=file(fn, 'wb')
-  f.write(pdb_lines)
+  f=open(fn, 'wb')
+  f.write(bytes(pdb_lines,encoding='utf8'))
   f.close()
   cmd = 'qr.finalise %s action="capping"' % (fn)
   if 0: print(cmd)
   rc = easy_run.go(cmd)
   os.remove(fn)
   fnc = '%s_capping.pdb' % fn.replace('.pdb','')
-  f=file(fnc, 'rb')
-  lines=f.read()
+  f=open(fnc, 'rb')
+  lines=f.read().decode('utf8')
   f.close()
   for line in [' HG  CYS A   3',
                ' HG  CYS A   8',

--- a/tests/unit/tst_28.py
+++ b/tests/unit/tst_28.py
@@ -35,15 +35,15 @@ ATOM   1348  HG  CYSSS  33      53.249  93.248  95.132  0.00102.06           H
 
 def run(prefix):
   fn='test_cys_cys_sym.pdb'
-  f=file(fn, 'wb')
-  f.write(pdb_lines)
+  f=open(fn, 'wb')
+  f.write(bytes(pdb_lines,encoding='utf8'))
   f.close()
   cmd = 'qr.finalise %s action="capping"' % (fn)
   if 0: print(cmd)
   rc = easy_run.go(cmd)
   os.remove(fn)
   fnc = '%s_capping.pdb' % fn.replace('.pdb','')
-  f=file(fnc, 'rb')
+  f=open(fnc, 'rb')
   lines=f.read()
   f.close()
   assert ' HG  CYS A  12' not in lines

--- a/tests/unit/tst_28.py
+++ b/tests/unit/tst_28.py
@@ -1,5 +1,7 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os, sys
-import run_tests
+from qrefine.tests.unit import run_tests
 from libtbx import easy_run
 import libtbx.load_env
 
@@ -37,7 +39,7 @@ def run(prefix):
   f.write(pdb_lines)
   f.close()
   cmd = 'qr.finalise %s action="capping"' % (fn)
-  if 0: print cmd
+  if 0: print(cmd)
   rc = easy_run.go(cmd)
   os.remove(fn)
   fnc = '%s_capping.pdb' % fn.replace('.pdb','')
@@ -47,7 +49,7 @@ def run(prefix):
   assert ' HG  CYS A  12' not in lines
   assert ' HG  CYSSS  33' not in lines
   cmd = 'qr.charges %s verbose=1' % (fnc)
-  if 0: print cmd
+  if 0: print(cmd)
   rc = easy_run.go(cmd)
   assert 'Charge: 0' in rc.stdout_lines
   os.remove(fnc)

--- a/tests/unit/tst_29.py
+++ b/tests/unit/tst_29.py
@@ -59,8 +59,8 @@ ATOM     89  HG3 GLU A 336       5.069  26.321  14.303  0.00 56.63           H
 
 def run(prefix):
   fn='test_one_alt_loc.pdb'
-  f=file(fn, 'wb')
-  f.write(pdb_lines)
+  f=open(fn, 'wb')
+  f.write(bytes(pdb_lines,encoding='utf8'))
   f.close()
   cmd = 'qr.charges %s verbose=1' % (fn)
   if 0: print(cmd)

--- a/tests/unit/tst_29.py
+++ b/tests/unit/tst_29.py
@@ -1,5 +1,7 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os, sys
-import run_tests
+from qrefine.tests.unit import run_tests
 from libtbx import easy_run
 import libtbx.load_env
 
@@ -61,7 +63,7 @@ def run(prefix):
   f.write(pdb_lines)
   f.close()
   cmd = 'qr.charges %s verbose=1' % (fn)
-  if 0: print cmd
+  if 0: print(cmd)
   rc = easy_run.go(cmd)
   assert 'Charge: -2' in rc.stdout_lines
   os.remove(fn)

--- a/tests/unit/tst_30.py
+++ b/tests/unit/tst_30.py
@@ -1,11 +1,12 @@
 from __future__ import division
+from __future__ import absolute_import
 
 import os
 import time
 import iotbx.pdb
 import mmtbx.f_model
 from scitbx.array_family import flex
-import run_tests
+from qrefine.tests.unit import run_tests
 import mmtbx.model
 from libtbx.utils import null_out
 from libtbx.test_utils import approx_equal

--- a/tests/unit/tst_31.py
+++ b/tests/unit/tst_31.py
@@ -1,4 +1,5 @@
-import run_tests
+from __future__ import absolute_import
+from qrefine.tests.unit import run_tests
 from ase import Atoms
 import warnings
 from libtbx.test_utils import approx_equal

--- a/tests/unit/tst_32.py
+++ b/tests/unit/tst_32.py
@@ -1,4 +1,5 @@
-import run_tests
+from __future__ import absolute_import
+from qrefine.tests.unit import run_tests
 from ase import Atoms
 import warnings
 import unittest

--- a/tests/unit/tst_33.py
+++ b/tests/unit/tst_33.py
@@ -1,4 +1,5 @@
-import run_tests
+from __future__ import absolute_import
+from qrefine.tests.unit import run_tests
 import os
 from ase import Atoms
 from qrefine.plugin.ase.pyscf_qr import Pyscf

--- a/tests/unit/tst_34.py
+++ b/tests/unit/tst_34.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import
 import os
-import run_tests
+from qrefine.tests.unit import run_tests
 from ase import Atoms
 import warnings
 from libtbx.test_utils import approx_equal

--- a/tests/unit/tst_35.py
+++ b/tests/unit/tst_35.py
@@ -1,8 +1,10 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 
 import time
 import os
-import run_tests
+from qrefine.tests.unit import run_tests
 import iotbx.pdb
 import libtbx.load_env
 
@@ -24,5 +26,5 @@ if(__name__ == "__main__"):
   t0 = time.time()
   prefix = os.path.basename(__file__).replace(".py","")
   run(prefix)
-  print prefix + ":  OK  " + "Time: %6.2f (s)" % (time.time() - t0)
+  print(prefix + ":  OK  " + "Time: %6.2f (s)" % (time.time() - t0))
   run_tests.clean_up(prefix)

--- a/tests/unit/tst_36.py
+++ b/tests/unit/tst_36.py
@@ -1,11 +1,12 @@
 from __future__ import division
+from __future__ import absolute_import
 
 import os
 import time
 import iotbx.pdb
 import mmtbx.f_model
 from scitbx.array_family import flex
-import run_tests
+from qrefine.tests.unit import run_tests
 import mmtbx.model
 from libtbx.utils import null_out
 from libtbx.test_utils import approx_equal

--- a/tests/unit/tst_37.py
+++ b/tests/unit/tst_37.py
@@ -1,11 +1,12 @@
 from __future__ import division
+from __future__ import absolute_import
 
 import os
 import time
 import iotbx.pdb
 import mmtbx.f_model
 from scitbx.array_family import flex
-import run_tests
+from qrefine.tests.unit import run_tests
 import mmtbx.model
 from libtbx.utils import null_out
 from libtbx.test_utils import approx_equal

--- a/tests/unit/tst_38.py
+++ b/tests/unit/tst_38.py
@@ -1,10 +1,12 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import iotbx.pdb
 from scitbx.array_family import flex
 from libtbx import easy_pickle
 import time, sys
-import run_tests
+from qrefine.tests.unit import run_tests
 import libtbx.load_env
 from libtbx.test_utils import approx_equal
 from libtbx import easy_run
@@ -303,8 +305,8 @@ def run(prefix):
           g1 = g1.as_double()
           g2 = g2.as_double()
           diff = flex.abs(g1-g2)
-          print "        min/max/mean of (gradient1 - gradient2):", \
-              diff.min_max_mean().as_tuple()
+          print("  min/max/mean of (gradient1 - gradient2):", \
+            diff.min_max_mean().as_tuple())
 
 if(__name__ == '__main__'):
   prefix = os.path.basename(__file__).replace(".py","")

--- a/tests/unit/tst_38.py
+++ b/tests/unit/tst_38.py
@@ -270,19 +270,19 @@ def run(prefix):
   Altlocs.
   """
   for i, pdb_str_in in enumerate([pdb_str_in1, pdb_str_in2]):
-    if(i==0): print "Altlocs present", "-"*30
-    else:     print "No altlocs", "-"*30
+    if(i==0): print("Altlocs present", "-"*30)
+    else:     print("No altlocs", "-"*30)
     pdb_in = "%s.pdb"%prefix
     open(pdb_in, "w").write(pdb_str_in)
     #
     for fast_interaction in [True, False]:
-      print "fast_interaction:", fast_interaction
+      print("fast_interaction:", fast_interaction)
       for restraints in ["cctbx", "qm"]:
-        print "  restraints:", restraints
+        print("  restraints:", restraints)
         for two_buffers in [False, True]:
-          print "    two_buffers=", two_buffers
+          print("    two_buffers=", two_buffers)
           for clustering in ["true", "false"]:
-            print "      clustering=", clustering
+            print("      clustering=", clustering)
             cmd = " ".join([
               "qr.refine",
               pdb_in,

--- a/tests/unit/tst_39.py
+++ b/tests/unit/tst_39.py
@@ -1,7 +1,8 @@
 from __future__ import division
+from __future__ import absolute_import
 
 import os
-import run_tests
+from qrefine.tests.unit import run_tests
 from mmtbx.pair_interaction import tst_01
 
 def run(prefix):

--- a/tests/unit/tst_40.py
+++ b/tests/unit/tst_40.py
@@ -1,7 +1,8 @@
 from __future__ import division
+from __future__ import absolute_import
 
 import os
-import run_tests
+from qrefine.tests.unit import run_tests
 from mmtbx.pair_interaction import tst_02
 
 

--- a/tests/unit/tst_41.py
+++ b/tests/unit/tst_41.py
@@ -1,7 +1,8 @@
 from __future__ import division
+from __future__ import absolute_import
 
 import os
-import run_tests
+from qrefine.tests.unit import run_tests
 from mmtbx.pair_interaction import tst_03
 
 

--- a/tests/unit/tst_42.py
+++ b/tests/unit/tst_42.py
@@ -1,10 +1,13 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import str
 import os
 import iotbx.pdb
 from scitbx.array_family import flex
 from libtbx import easy_pickle
 import time, sys
-import run_tests
+from qrefine.tests.unit import run_tests
 import libtbx.load_env
 from libtbx.test_utils import approx_equal
 from libtbx import easy_run
@@ -288,13 +291,13 @@ def run(prefix):
   open(pdb_in, "w").write(pdb_str_in)
   #
   for fast_interaction in [True, False]:
-    print "fast_interaction:", fast_interaction
+    print("fast_interaction:", fast_interaction)
     for restraints in ["cctbx", "qm"]:
-      print "  restraints:", restraints
+      print("  restraints:", restraints)
       for two_buffers in [False, True]:
-        print "    two_buffers=", two_buffers
+        print("    two_buffers=", two_buffers)
         for clustering in ["true", "false"]:
-          print "      clustering=", clustering 
+          print("      clustering=", clustering) 
           cmd = " ".join([
             "qr.refine",
             pdb_in,
@@ -316,8 +319,8 @@ def run(prefix):
         g1 = g1.as_double()
         g2 = g2.as_double()
         diff = flex.abs(g1-g2)
-        print "        min/max/mean of (gradient1 - gradient2):", \
-            diff.min_max_mean().as_tuple()
+        print("        min/max/mean of (gradient1 - gradient2):", \
+            diff.min_max_mean().as_tuple())
 
 if(__name__ == '__main__'):
   prefix = os.path.basename(__file__).replace(".py","")

--- a/tests/unit/tst_43.py
+++ b/tests/unit/tst_43.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 import random
@@ -12,7 +14,7 @@ from qrefine.cluster_restraints import from_cluster
 from qrefine.restraints import from_qm, from_cctbx
 from qrefine.fragment import fragments
 from qrefine.clustering import betweenness_centrality_clustering
-import run_tests
+from qrefine.tests.unit import run_tests
 import mmtbx.model
 from libtbx.utils import null_out
 from qrefine import qr
@@ -50,7 +52,7 @@ def get_model():
 def run(maxnum_residues_in_cluster):
   result = []
   for clustering in [True, False]:
-    print "  clustering", clustering, "-"*30
+    print("  clustering", clustering, "-"*30)
     model = get_model()
     fq = from_cctbx(restraints_manager = model.get_restraints_manager())
     if(clustering):
@@ -82,5 +84,5 @@ def run(maxnum_residues_in_cluster):
 
 if(__name__ == "__main__"):
   for maxnum_residues_in_cluster in [2, 15]:
-    print "Using maxnum_residues_in_cluster:", maxnum_residues_in_cluster
+    print("Using maxnum_residues_in_cluster:", maxnum_residues_in_cluster)
     run(maxnum_residues_in_cluster=maxnum_residues_in_cluster)

--- a/tests/unit/tst_44.py
+++ b/tests/unit/tst_44.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 
 import os
 import iotbx.pdb
@@ -34,7 +35,7 @@ def run():
     fn = path + fn
     ph = iotbx.pdb.input(fn).construct_hierarchy()
     if list(ph.altloc_indices()) != ['']: continue
-    print fn
+    print(fn)
     #
     rm1, sites_cart = get_restraints_manager(expansion=False, file_name=fn)
     t1, g1 = rm1.target_and_gradients(sites_cart = sites_cart)
@@ -43,7 +44,7 @@ def run():
     t2, g2 = rm2.target_and_gradients(sites_cart = sites_cart)
     #
     diff = flex.abs(g1.as_double()-g2.as_double())
-    print diff.min_max_mean().as_tuple()
+    print(diff.min_max_mean().as_tuple())
     assert flex.max(diff) < 1.e-6
 
 if(__name__ == "__main__"):

--- a/utils/electrons.py
+++ b/utils/electrons.py
@@ -5,6 +5,7 @@ from cctbx.array_family import flex
 import mmtbx.model
 import sys
 import time
+from functools import cmp_to_key
 
 atom_database = {'H' : {'valence' : 1},
                  #
@@ -200,7 +201,7 @@ class electron_distribution(dict):
         l = []
         for bp in simple:
           l.append(bp)
-        l.sort(_sort_lone_pairs)
+        l.sort(key=cmp_to_key(_sort_lone_pairs))
         for bp in l:
           yield bp
       else:
@@ -407,8 +408,8 @@ def run(pdb_filename=None,
     assert 0
 
   # create a model manager
-  import StringIO
-  log = StringIO.StringIO()
+  import io
+  log = io.StringIO()
   default_scope = mmtbx.model.manager.get_default_pdb_interpretation_scope()
   working_params = default_scope.extract()
   # optional???

--- a/utils/electrons.py
+++ b/utils/electrons.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 import iotbx.pdb
 from cctbx.array_family import flex
 import mmtbx.model
@@ -113,12 +114,12 @@ class electron_distribution(dict):
   def _add_electron_to_bond(self, i_seqs):
     if 0:
       atoms = self.hierarchy.atoms()
-      print i_seqs, atoms[i_seqs[0]].quote(), atoms[i_seqs[1]].quote()
-      print self
+      print(i_seqs, atoms[i_seqs[0]].quote(), atoms[i_seqs[1]].quote())
+      print(self)
     self[i_seqs]+=1
     self[i_seqs[0]]-=1
     self[i_seqs[1]]-=1
-    if 0: print self
+    if 0: print(self)
 
   def form_bonds(self, extend_based_on_proximity=False, verbose=False):
     if self.verbose or verbose: verbose=1
@@ -135,10 +136,10 @@ class electron_distribution(dict):
       return max_valence==0
     def _can_denote_electron_to_covalent_bond(i_seq, j_seq, verbose=False):
       if verbose:
-        print 'processing %s %s' % (atoms[i_seq].quote(), atoms[j_seq].quote())
+        print('processing %s %s' % (atoms[i_seq].quote(), atoms[j_seq].quote()))
       if self[i_seq]>0 and self[j_seq]>0:
         if verbose:
-            print 'bonding %s %s' % (atoms[i_seq].quote(), atoms[j_seq].quote())
+            print('bonding %s %s' % (atoms[i_seq].quote(), atoms[j_seq].quote()))
         return True
       elif self[i_seq]==0 and self[j_seq]==0:
         return False
@@ -166,13 +167,13 @@ class electron_distribution(dict):
         else:
           return False
         if verbose:
-          print 'other-lp   %s-%s' % (other.quote(), lone_pair.quote())
+          print('other-lp   %s-%s' % (other.quote(), lone_pair.quote()))
         if self[other.i_seq]>0:
           return True
         return False
       if self.properties.get_lone_pairs(other.element):
         #self[other.i_seq]+=2
-        if verbose: print 'hydrogen-X lone pair TRUE'
+        if verbose: print('hydrogen-X lone pair TRUE')
         return True
       return None
     ###
@@ -242,7 +243,7 @@ class electron_distribution(dict):
       self[bp.i_seqs]=0
       if _can_denote_electron_to_covalent_bond(i_seq, j_seq):
         self._add_electron_to_bond(bp.i_seqs)
-        if verbose: print 'single: %s-%s\n%s' % (atoms[i_seq].quote(), atoms[j_seq].quote(),self)
+        if verbose: print('single: %s-%s\n%s' % (atoms[i_seq].quote(), atoms[j_seq].quote(),self))
     # look for double bonds
     for bp in generate_bonds_from_simple(simple,
                                          sort_on_lone_pairs=True,
@@ -253,12 +254,12 @@ class electron_distribution(dict):
       assert j_seq in self
       while self[i_seq]>0 and self[j_seq]>0:
         self._add_electron_to_bond(bp.i_seqs)
-        if verbose: print 'double',self
-        if verbose: print 'bonding 2',atoms[i_seq].quote(), atoms[j_seq].quote()
+        if verbose: print('double',self)
+        if verbose: print('bonding 2',atoms[i_seq].quote(), atoms[j_seq].quote())
     # look for hyper-valance bonds
     for bp in simple:
       if bp.i_seqs not in self: continue
-      if verbose: print 'hyper',self
+      if verbose: print('hyper',self)
       i_seq, j_seq = bp.i_seqs
       assert i_seq in self
       assert j_seq in self
@@ -294,14 +295,14 @@ class electron_distribution(dict):
                   bond2 = key
           if bond0 and bond1 and bond2:
             if verbose:
-              print '-'*80
-              print bond0, bond1, bond2
-              print atoms[bond0[0]].quote()
-              print atoms[bond0[1]].quote()
-              print atoms[bond1[0]].quote()
-              print atoms[bond1[1]].quote()
-              print atoms[bond2[0]].quote()
-              print atoms[bond2[1]].quote()
+              print('-'*80)
+              print(bond0, bond1, bond2)
+              print(atoms[bond0[0]].quote())
+              print(atoms[bond0[1]].quote())
+              print(atoms[bond1[0]].quote())
+              print(atoms[bond1[1]].quote())
+              print(atoms[bond2[0]].quote())
+              print(atoms[bond2[1]].quote())
             self[bond1]-=1
             self[bond2]-=1
             self[bond1[0]]+=1
@@ -316,8 +317,8 @@ class electron_distribution(dict):
       rc = self.get_possible_covalent_bonds()
       for i_seq, j_seq in rc:
         if verbose:
-          print '  forming bond between %s %s' % (atoms[i_seq].quote(),
-                                                  atoms[j_seq].quote())
+          print('  forming bond between %s %s' % (atoms[i_seq].quote(),
+                                                  atoms[j_seq].quote()))
         assert (i_seq, j_seq) not in self
         self[(i_seq, j_seq)] = 1
         self[i_seq]-=1
@@ -373,7 +374,7 @@ class electron_distribution(dict):
       rc.append(i_seq)
     if verbose:
       for i_seq in rc:
-        print i_seq, self.atoms[i_seq].quote()
+        print(i_seq, self.atoms[i_seq].quote())
     return rc
 
   def get_total_charge(self):
@@ -427,7 +428,7 @@ def run(pdb_filename=None,
     model.get_restraints_manager().geometry,
     verbose=verbose,
   )
-  if verbose: print atom_valences
+  if verbose: print(atom_valences)
   total_charge = atom_valences.get_total_charge()
   #print 'total_charge',total_charge
   #print 'time %0.1f' % (time.time()-t0)
@@ -458,8 +459,8 @@ def run(pdb_filename=None,
   # update model manager with this xray structure
   model.set_xray_structure(xrs)
   # output result in PDB format to the screen
-  print model.model_as_pdb()
-  print "END"
+  print(model.model_as_pdb())
+  print("END")
 
 if (__name__ == "__main__"):
   run(args=sys.argv[1:])

--- a/utils/hierarchy_utils.py
+++ b/utils/hierarchy_utils.py
@@ -149,10 +149,10 @@ def write_hierarchy(pdb_filename, pdb_inp, hierarchy, underscore):
                           underscore,
                           )
   output = os.path.basename(output)
-  f=file(output, "wb")
-  f.write(hierarchy.as_pdb_string(
-    crystal_symmetry=pdb_inp.crystal_symmetry()),
-          )
+  f=open(output, "wb")
+  f.write(bytes(hierarchy.as_pdb_string(
+    crystal_symmetry=pdb_inp.crystal_symmetry())
+          ,encoding='utf8'))
   f.close()
   return output
 
@@ -198,9 +198,9 @@ def add_hydrogens_using_ReadySet(pdb_filename,
     sys.stdout = sys_std
   if 0:
     #print 'overwriting',pdb_filename
-    f=file(pdb_filename, 'wb')
+    f=open(pdb_filename, 'wb')
     for line in rc['cryst1']:
-      f.write('%s\n' % line)
+      f.write(bytes('%s\n' % line),encoding='utf8')
     f.write(rc['model_hierarchy'].as_pdb_string())
     f.close()
   else:

--- a/utils/hierarchy_utils.py
+++ b/utils/hierarchy_utils.py
@@ -1,10 +1,6 @@
 from __future__ import print_function
 import os, sys
-try:
-    from StringIO import StringIO ## for Python 2
-except ImportError:
-    from io import StringIO ## for Python 3
-# import StringIO
+from io import StringIO
 import iotbx
 from libtbx.utils import Sorry
 from mmtbx import monomer_library
@@ -158,7 +154,6 @@ def write_hierarchy(pdb_filename, pdb_inp, hierarchy, underscore):
     crystal_symmetry=pdb_inp.crystal_symmetry()),
           )
   f.close()
-  #print "\n  Output written to: %s" % output
   return output
 
 def get_raw_records(pdb_inp=None,
@@ -185,7 +180,7 @@ def add_hydrogens_using_ReadySet(pdb_filename,
   sys_std = None
   if 1:
     sys_std = sys.stdout
-    sys.stdout = StringIO.StringIO()
+    sys.stdout = io.StringIO()
     print('NOT'*20)
   rc = run_though_all_the_options(
     pdb_lines,

--- a/utils/hierarchy_utils.py
+++ b/utils/hierarchy_utils.py
@@ -1,5 +1,10 @@
+from __future__ import print_function
 import os, sys
-import StringIO
+try:
+    from StringIO import StringIO ## for Python 2
+except ImportError:
+    from io import StringIO ## for Python 3
+# import StringIO
 import iotbx
 from libtbx.utils import Sorry
 from mmtbx import monomer_library
@@ -23,7 +28,7 @@ def display_residue_group_from_hierarchy(hierarchy,
   for rg in hierarchy.residue_groups():
     if rg.resseq.strip()==str(resseq):
       for atom in rg.atoms():
-        print atom.quote()
+        print(atom.quote())
 
 def display_atom_group(ag, verbose=False):
   if verbose:
@@ -45,12 +50,12 @@ def generate_residues_via_conformer(hierarchy,
   loop_hierarchy=hierarchy
   if backbone_only: loop_hierarchy=backbone_hierarchy
   for model in loop_hierarchy.models():
-    if verbose: print 'model: "%s"' % model.id
+    if verbose: print('model: "%s"' % model.id)
     for chain in model.chains():
-      if verbose: print 'chain: "%s"' % chain.id
+      if verbose: print('chain: "%s"' % chain.id)
       for conformer in chain.conformers():
-        if verbose: print '  conformer: altloc="%s"' % (
-          conformer.altloc)
+        if verbose: print('  conformer: altloc="%s"' % (
+          conformer.altloc))
 #        while threes: del threes[0]
 #        threes.start=None
 #        threes.end=None
@@ -58,9 +63,9 @@ def generate_residues_via_conformer(hierarchy,
         for residue in conformer.residues():
           if verbose:
             if residue.resname not in ["HOH"]:
-              print '    residue: resname="%s" resid="%s"' % (
-                residue.resname, residue.resid())
-          if verbose: print '      residue class : %s' % get_class(residue.resname)
+              print('    residue: resname="%s" resid="%s"' % (
+                residue.resname, residue.resid()))
+          if verbose: print('      residue class : %s' % get_class(residue.resname))
           if get_class(residue.resname) not in ["common_amino_acid",
                                                 'modified_amino_acid',
                                               ]:
@@ -100,9 +105,9 @@ def generate_protein_fragments(hierarchy,
                                                  verbose=verbose,
                                                  ):
     list.append(threes, residue)
-    if verbose: print 'THREE',threes
+    if verbose: print('THREE',threes)
     sub_unit = threes.provide_second_sub_unit_if_unlinked()
-    if verbose: print 'THREE, SUBUNIT',threes, sub_unit
+    if verbose: print('THREE, SUBUNIT',threes, sub_unit)
     if sub_unit:
       threes.start = True
       threes.end = True
@@ -181,7 +186,7 @@ def add_hydrogens_using_ReadySet(pdb_filename,
   if 1:
     sys_std = sys.stdout
     sys.stdout = StringIO.StringIO()
-    print 'NOT'*20
+    print('NOT'*20)
   rc = run_though_all_the_options(
     pdb_lines,
     [], # args
@@ -194,7 +199,7 @@ def add_hydrogens_using_ReadySet(pdb_filename,
     output_file_name=output_file_name, # needed
     )
   if sys_std:
-    print 'NOT'*20
+    print('NOT'*20)
     sys.stdout = sys_std
   if 0:
     #print 'overwriting',pdb_filename

--- a/utils/make_version.py
+++ b/utils/make_version.py
@@ -13,6 +13,7 @@
   For development updates please execute: phenix.python utils/make_version.py
 
 """
+from __future__ import print_function
 
 import os
 from subprocess import Popen,PIPE,STDOUT
@@ -25,7 +26,7 @@ def main(init_filename=None):
   git_command='git describe --abbrev=6 --dirty --always --tags'
   shell = Popen([git_command], shell=True, stderr=PIPE,stdout=PIPE)
   out, err = shell.communicate()
-  print 'Current version is %s ' % (out.rstrip())
+  print('Current version is %s ' % (out.rstrip()))
   version='__version__=\" %s  \"'% (out.rstrip())
 
   with open(init_filename,'w') as outfile:

--- a/utils/model_statistics.py
+++ b/utils/model_statistics.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import iotbx.pdb
 from mmtbx import monomer_library
@@ -52,8 +53,8 @@ def get_model_stat(pdb_file_name=None, pdb_hierarchy=None,
     restraints_manager = restraints_manager,
     molprobity_scores  = True)
   if(show):
-    print "-"*79
+    print("-"*79)
     stats.show(out=sys.stdout)
-    print "-"*79
+    print("-"*79)
   #
   return stats


### PR DESCRIPTION
# Pull Request
Embracing the future going python3. No more python2.x support.

The focus, for now, is to run `qr.refine` with and without clustering.
This post will be updated over time to reflect the status.

@qrefine/qrefine-dev feedback, code review and testing on different machines/setups is encouraged!

## How to run this branch
- download cctbx [bootstrap.py]( https://raw.githubusercontent.com/cctbx/cctbx_project/master/libtbx/auto_build/bootstrap.py) into an empty directory. (Can use `wget <url>`)
- run `python3 bootstrap.py --use-conda --python 37`
- run `source build/setpaths_all.sh`
- run `cctbx.python -m pip install pymongo ase JPype1==0.6.3`
- run `git clone https://github.com/qrefine/qrefine.git modules/qrefine`
- copy `chem_data` from phenix/modules to modules of the cctbx install
- go into qrefine directory and switch to this branch `git checkout qr_py3`
- run `libtbx.configure qrefine`
- apply fixes for cctbx as outlined in #60 


## Current limitations
- no `qr.finalize`; needs elbow and Plex in python3 (comes when phenix finishes move to py3)
-  no restart files! (pickling) (search code for `PY3_TODO`), see issue #61 
-  only the xtb/mopac ASE plugins are tested!
-  tests known to fail: 07,12,13,16,18,30,36,38,41

## ToDo
- decide on bytes vs strings for files