### PR TITLE
fix aimnet2 restraint

### DIFF
--- a/restraints.py
+++ b/restraints.py
@@ -475,7 +475,8 @@ class from_qm(object):
       calculator = AIMNet2CalculatorOLD()
     elif(self.qm_engine_name == "aimnet2"):
       from .plugin.ase.aimnet2_qr import AIMNet2Calculator
-      calculator = AIMNet2Calculator('aimnet2-qr')
+      model = 'aimnet2-qr' if self.method == 'rhf' else self.method  # replace class default method
+      calculator = AIMNet2Calculator(model)
     elif(self.qm_engine_name == "xtb"):
       calculator = GFNxTB()
     elif(self.qm_engine_name == "server"):

--- a/restraints.py
+++ b/restraints.py
@@ -475,7 +475,7 @@ class from_qm(object):
       calculator = AIMNet2CalculatorOLD()
     elif(self.qm_engine_name == "aimnet2"):
       from .plugin.ase.aimnet2_qr import AIMNet2Calculator
-      calculator = AIMNet2Calculator(self.method)
+      calculator = AIMNet2Calculator('aimnet2-qr')
     elif(self.qm_engine_name == "xtb"):
       calculator = GFNxTB()
     elif(self.qm_engine_name == "server"):


### PR DESCRIPTION
fix for initialization of AIMNet2Calculator in restraints.py
model jtp file would be downloaded at first call from https://github.com/zubatyuk/aimnet-model-zoo/raw/main/aimnet2-qr/aimnet2-qr_b97md4_qzvp_2.jpt as defined in https://github.com/zubatyuk/aimnet2calc/blob/main/aimnet2calc/models.py