### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-dockerhub.yaml
+++ b/.github/workflows/publish-dockerhub.yaml
@@ -3,6 +3,9 @@ name: Publish image to public repository on dockerhub
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   container_name: qrefine/cctbx-qr
   


### PR DESCRIPTION
Potential fix for [https://github.com/qrefine/qrefine/security/code-scanning/1](https://github.com/qrefine/qrefine/security/code-scanning/1)

Generally, the fix is to define an explicit `permissions` block that grants only the minimal required access to `GITHUB_TOKEN`. For this workflow, no step needs to write to the GitHub repository or issues; it only checks out code and uses Docker Hub credentials. Therefore, `contents: read` at either the workflow root or at the `push` job level is sufficient. This documents that only read access to repository contents is needed and prevents future accidental escalation if org defaults change.

The single best fix without changing existing functionality is to add a root-level `permissions` block between the `on:` and `env:` sections in `.github/workflows/publish-dockerhub.yaml`:

```yaml
permissions:
  contents: read
```

This applies to all jobs that don’t override it. No imports or other code changes are needed. Only this YAML file needs a one-line addition and one line of indentation (the key plus its value line).

Concretely, in `.github/workflows/publish-dockerhub.yaml`, after line 5 (`workflow_dispatch:`) and its blank line, insert:

```yaml
permissions:
  contents: read
```

leaving the rest of the file unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
